### PR TITLE
ci: Add build step and update pnpm to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -24,4 +24,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm prettier --check .
       - run: pnpm lint
+      - run: pnpm build
       - run: pnpm test


### PR DESCRIPTION
## Summary
- Add `pnpm build` (tsc) step to CI pipeline to catch TypeScript compilation errors
- Update pnpm from v9 to v10 to match local and deploy workflows

## Test plan
- [ ] CI runs successfully with pnpm 10
- [ ] Build step catches TypeScript errors
- [ ] All existing checks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)