### PR TITLE
feat: Add doc:start script to launch Docusaurus from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:fix": "eslint --fix .",
     "check": "prettier --check . && eslint .",
     "check:fix": "prettier --write . && eslint --fix .",
+    "doc:start": "pnpm --dir doc start",
     "prepare": "husky",
     "prepublishOnly": "tsc && vitest run"
   },


### PR DESCRIPTION
## Summary
- Add `doc:start` script to root `package.json` so the Docusaurus dev server can be launched with `pnpm doc:start` without `cd doc`

## Test plan
- [x] Verified `pnpm doc:start` launches dev server and returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)