### PR TITLE
docs: Add GitHub commit links to changelog entries

### DIFF
--- a/doc/docs/changelog/v0.1.0.mdx
+++ b/doc/docs/changelog/v0.1.0.mdx
@@ -8,23 +8,23 @@ Released: 2026-02-07
 
 ## Features
 
-- Add /version-increment skill for release workflow (6e18b0d)
+- Add /version-increment skill for release workflow ([6e18b0d](https://github.com/Takazudo/mdx-formatter/commit/6e18b0dd968f44ce43d99e414853aaac74730649))
 
 ## Bug Fixes
 
-- Avoid bare backtick-exclamation in version-increment skill (8911989)
-- Exclude docs/ from Prettier check and fix package.json formatting (2a6872d)
-- Fix bugs found in code review and remove dead code (1785c0e, 1b73e1a)
+- Avoid bare backtick-exclamation in version-increment skill ([8911989](https://github.com/Takazudo/mdx-formatter/commit/89119899a5fb70ad4947831033962bae1ad0c9f8))
+- Exclude docs/ from Prettier check and fix package.json formatting ([2a6872d](https://github.com/Takazudo/mdx-formatter/commit/2a6872d4cd3067864e972e8be020a866d3b6d0d7))
+- Fix bugs found in code review and remove dead code ([1785c0e](https://github.com/Takazudo/mdx-formatter/commit/1785c0ef5bc98c6c3c06e0ce5bab1d13fa54e828), [1b73e1a](https://github.com/Takazudo/mdx-formatter/commit/1b73e1a5b686b0b25c0d18c7ec0a10198825dff5))
 
 ## Other Changes
 
-- Add Docusaurus doc site with Overview, Options, and Formatting sections (736d03c)
-- Add Changelog category to doc site (1a3a71b)
-- Add CLAUDE.md files for project, src, test, and doc directories (4d031c3)
-- Use npm/npx instead of pnpm in user-facing install examples (ab36cc1)
-- Slim down README, move detailed content to doc site (102b914)
-- Add complete options reference to README (fd027f8)
-- Add Docusaurus build/deploy workflow and project config updates (6ffb730)
-- Consolidate test files by feature instead of development process (a80e0e8)
-- Consolidate shared types, add access modifiers, clean up casts (cc91904)
-- Migrate entire codebase from JavaScript to TypeScript (4afb5d8)
+- Add Docusaurus doc site with Overview, Options, and Formatting sections ([736d03c](https://github.com/Takazudo/mdx-formatter/commit/736d03c3dc8c368f076460ada6fc91bd08e84bf4))
+- Add Changelog category to doc site ([1a3a71b](https://github.com/Takazudo/mdx-formatter/commit/1a3a71b4c0ee6388db903f69a052da644bc48064))
+- Add CLAUDE.md files for project, src, test, and doc directories ([4d031c3](https://github.com/Takazudo/mdx-formatter/commit/4d031c347ac1af26c10e8a7292a6f7ba962d3c63))
+- Use npm/npx instead of pnpm in user-facing install examples ([ab36cc1](https://github.com/Takazudo/mdx-formatter/commit/ab36cc169df7abc8b8f1dc4dc3fe7033b290d56f))
+- Slim down README, move detailed content to doc site ([102b914](https://github.com/Takazudo/mdx-formatter/commit/102b914a4a8120fd48d9cd299041caad478b48a9))
+- Add complete options reference to README ([fd027f8](https://github.com/Takazudo/mdx-formatter/commit/fd027f80ce66ec168b2e41f535740503b227a5b0))
+- Add Docusaurus build/deploy workflow and project config updates ([6ffb730](https://github.com/Takazudo/mdx-formatter/commit/6ffb730b237f8845302b632dab8e5f57c573b3b1))
+- Consolidate test files by feature instead of development process ([a80e0e8](https://github.com/Takazudo/mdx-formatter/commit/a80e0e8c50aded7717ffc672d8decc9dc8be3fd6))
+- Consolidate shared types, add access modifiers, clean up casts ([cc91904](https://github.com/Takazudo/mdx-formatter/commit/cc91904e2fbf3b9cc8c2c74b11d7c822d9ace1a1))
+- Migrate entire codebase from JavaScript to TypeScript ([4afb5d8](https://github.com/Takazudo/mdx-formatter/commit/4afb5d823d511b308ca3bbb3769f803bf99e893b))

--- a/doc/docs/changelog/v0.1.1.mdx
+++ b/doc/docs/changelog/v0.1.1.mdx
@@ -8,5 +8,5 @@ Released: 2026-02-07
 
 ## Bug Fixes
 
-- Correct URLs and add icons to doc site links (f2f2d20)
-- Format SKILL.md and add .claude/ to lint-staged (f14e411)
+- Correct URLs and add icons to doc site links ([f2f2d20](https://github.com/Takazudo/mdx-formatter/commit/f2f2d208a5a4458b0ffc1cc4a112b619c85963ef))
+- Format SKILL.md and add .claude/ to lint-staged ([f14e411](https://github.com/Takazudo/mdx-formatter/commit/f14e4117dae89ac5a696aa2d76ed7ccee4fd77d9))

--- a/doc/docs/changelog/v0.1.2.mdx
+++ b/doc/docs/changelog/v0.1.2.mdx
@@ -8,4 +8,4 @@ Released: 2026-02-09
 
 ## Bug Fixes
 
-- Add CI wait step to version-increment and cover doc/src in lint-staged (709df1c)
+- Add CI wait step to version-increment and cover doc/src in lint-staged ([709df1c](https://github.com/Takazudo/mdx-formatter/commit/709df1c71986ca0e4ed1be5d67d486af5d5dab98))


### PR DESCRIPTION
## Summary
- Add clickable GitHub commit links to all commit hashes in changelog docs (v0.1.0, v0.1.1, v0.1.2)

## Test plan
- [ ] Verify links render correctly on doc site
- [ ] Verify links point to correct commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)