### PR TITLE
docs: Add Contribution page to Overview section

### DIFF
--- a/doc/docs/overview/contribution.mdx
+++ b/doc/docs/overview/contribution.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_position: 8
+---
+
+# Contribution
+
+This project is a Markdown/MDX formatter. I originally built it because I needed this functionality for one of my projects. It started as a sub-package within that project, but since I use a documentation tool for all of my projects, I found myself copying and pasting the package into every project directory. So I published it to npm for consistency and easier maintenance.
+
+Most of the source code in this project was written by [Claude Code](https://claude.ai/). While this is publicly available as an open-source project, I'm not sure whether I'll actively maintain the package going forward. Feel free to fork it or open pull requests, but I can't guarantee that I'll be able to review or merge them.
+
+Since we're already in the AI era, I'd recommend forking the repo and making whatever tweaks you need on your own.
+
+-- [@Takazudo](https://x.com/Takazudo)

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -21,6 +21,7 @@ const sidebars = {
     'overview/usage',
     'overview/configuration',
     'overview/api',
+    'overview/contribution',
   ],
   optionsSidebar: [
     'options/index',


### PR DESCRIPTION
## Summary
- Add Contribution doc explaining the project's origin and maintenance expectations
- Add to overview sidebar

## Test plan
- [ ] Page renders correctly at /docs/overview/contribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)