### PR TITLE
Fix table breakage caused by inline JSX elements in table cells

### DIFF
--- a/src/hybrid-formatter.ts
+++ b/src/hybrid-formatter.ts
@@ -327,6 +327,11 @@ export class HybridFormatter {
           return;
         }
         const endLine = jsxNode.position!.end.line - 1;
+        // Skip JSX elements inside table rows
+        const currentLineContent = this.lines[endLine];
+        if (currentLineContent && currentLineContent.trim().startsWith('|')) {
+          return;
+        }
         if (endLine < this.lines.length - 1) {
           const nextLine = this.lines[endLine + 1];
           // Check if next line is text (not empty, not heading)

--- a/test/hybrid-formatter.test.ts
+++ b/test/hybrid-formatter.test.ts
@@ -1338,4 +1338,58 @@ Content`;
       expect(result).toContain('    <div class="inner">');
     });
   });
+
+  describe('Table with inline JSX elements', () => {
+    it('should not insert empty lines between table rows containing inline JSX elements', async () => {
+      const input = `| Key | Action |
+| --- | ------ |
+| <kbd>Tab</kbd> | Move focus |
+| <kbd>Enter</kbd> | Activate |
+| <kbd>Escape</kbd> | Close |`;
+
+      const formatter = new HybridFormatter(input, settings);
+      const result = await formatter.format();
+      expect(result).toBe(input);
+    });
+
+    it('should not insert empty lines between table rows with mixed inline HTML elements', async () => {
+      const input = `| Element | Description |
+| --- | --- |
+| <code>const</code> | Variable declaration |
+| <strong>bold</strong> | Bold text |
+| <em>italic</em> | Italic text |`;
+
+      const formatter = new HybridFormatter(input, settings);
+      const result = await formatter.format();
+      expect(result).toBe(input);
+    });
+
+    it('should still add spacing after JSX components outside tables', async () => {
+      const input = `<ExternalLink url="https://example.com" />
+Some text after the component.`;
+
+      const expected = `<ExternalLink url="https://example.com" />
+
+Some text after the component.`;
+
+      const formatter = new HybridFormatter(input, settings);
+      const result = await formatter.format();
+      expect(result).toBe(expected);
+    });
+
+    it('should maintain spacing around tables with headings and paragraphs', async () => {
+      const input = `## Keyboard Shortcuts
+
+| Key | Action |
+| --- | ------ |
+| <kbd>Tab</kbd> | Move focus |
+| <kbd>Enter</kbd> | Activate |
+
+Some text after the table.`;
+
+      const formatter = new HybridFormatter(input, settings);
+      const result = await formatter.format();
+      expect(result).toBe(input);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- GFMテーブルのセル内に `<kbd>` 等のインラインHTML/JSX要素があると、`addEmptyLineBetweenElements` によりテーブル行間に空行が挿入されテーブルが壊れるバグを修正
- `collectSpacingOperations` 内で、JSX要素がテーブル行（`|` で始まる行）上にある場合は空行挿入をスキップする条件を追加
- 4つのテストケースを追加（テーブル内インラインJSX、混合HTML要素、テーブル外JSXの空行維持、heading/table/paragraphのスペーシング）

## Test plan

- [x] `pnpm test` — 全255テスト通過
- [ ] `<kbd>`, `<code>`, `<strong>` 等を含むGFMテーブルがフォーマット後も壊れないこと
- [ ] テーブル外のJSXコンポーネント後の空行挿入は引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)