### PR TITLE
Add GitHub release creation to version increment skill

### DIFF
--- a/.claude/skills/l-version-increment/SKILL.md
+++ b/.claude/skills/l-version-increment/SKILL.md
@@ -173,13 +173,20 @@ Then check CI status with `gh run list --branch main --limit 2`. Poll every 30 s
 
 **Do not tag or publish until CI is green.**
 
-## Tag and push tag
+## Tag, push tag, and create GitHub release
 
 **Ask the user for confirmation before tagging.**
 
 ```bash
 git tag v{VERSION}
 git push --tags
+```
+
+After pushing the tag, create a GitHub release using the changelog content (with YAML frontmatter and `# v{VERSION}` heading stripped, since the release title already shows the version):
+
+```bash
+NOTES=$(awk 'BEGIN{s=0;f=0}/^---$/{if(!f){f=1;s=1;next}else if(s){s=0;next}}/^# v/{next}!s{print}' doc/docs/changelog/v{VERSION}.mdx)
+gh release create v{VERSION} --title "v{VERSION}" --notes "$NOTES"
 ```
 
 ## Publish to npm


### PR DESCRIPTION
## Summary

- Add `gh release create` step to `/l-version-increment` skill after tag push
- Strip YAML frontmatter and `# v{VERSION}` heading from changelog mdx before using as release notes (avoids duplicate title with GitHub's release title)

## Test Plan

- [x] Verified with v0.4.1 release and backfilled v0.1.0–v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)