### PR TITLE
docs: add admonition usage notes for block JSX and indent options

### DIFF
--- a/doc/docs/options/add-empty-lines-in-block-jsx.mdx
+++ b/doc/docs/options/add-empty-lines-in-block-jsx.mdx
@@ -80,6 +80,38 @@ Important information
 </InfoBox>
 ````
 
+### Admonition-like components (recommended use case)
+
+This option is particularly useful for admonition-style components (`<Note>`, `<Warning>`, `<Danger>`, etc.) commonly used in documentation frameworks like Docusaurus and Astro.
+
+In MDX, content inside JSX tags **requires blank lines** to be parsed as markdown. Without them, the content may be treated as raw text — headings, lists, bold, and other markdown syntax won't render.
+
+With `blockComponents: ["Note", "Warning", "Danger"]`:
+
+Before (markdown not parsed):
+
+````markdown
+<Note>
+**Important:** This text won't be bold.
+
+- This won't render as a list
+</Note>
+````
+
+After (markdown parsed correctly):
+
+````markdown
+<Note>
+
+**Important:** This text will be bold.
+
+- This renders as a list
+
+</Note>
+````
+
+The blank line after `<Note>` is what tells the MDX parser to treat the content as markdown.
+
 ### Non-listed components are not affected
 
 Components not in `blockComponents` are left alone:
@@ -91,3 +123,7 @@ Content without extra empty lines.
 ````
 
 This stays unchanged.
+
+## Caution with indentJsxContent
+
+If you also use [`indentJsxContent`](./indent-jsx-content) on the same components, be careful. Indenting markdown content inside admonitions can break rendering — in standard markdown, 4 or more spaces of indentation creates a code block. See the [indentJsxContent caution section](./indent-jsx-content#caution-with-markdown-content) for details.

--- a/doc/docs/options/indent-jsx-content.mdx
+++ b/doc/docs/options/indent-jsx-content.mdx
@@ -97,3 +97,55 @@ Content stays as-is.
 ````
 
 This stays unchanged.
+
+## Caution with markdown content
+
+**Do not use this option on components that contain markdown content** (admonitions like `<Note>`, `<Warning>`, `<Danger>`, `<Tabs>`, `<TabItem>`, etc.).
+
+In standard markdown, **4 or more spaces of indentation creates a code block**. If you indent markdown content inside a JSX component, the markdown parser may misinterpret the content.
+
+For example, with `containerComponents: ["Note"]` and `indentSize: 4`:
+
+````markdown
+<Note>
+
+    This looks like a code block to the markdown parser.
+
+    - This list won't render as a list either.
+
+</Note>
+````
+
+Even with `indentSize: 2`, combining with already-indented content (like nested lists or code blocks) can push lines past the 4-space threshold.
+
+### What to use instead
+
+For admonition-like components, use [`addEmptyLinesInBlockJsx`](./add-empty-lines-in-block-jsx) instead. It adds the blank lines needed for MDX to parse content as markdown, without changing indentation:
+
+````markdown
+<Note>
+
+**This bold text** renders correctly.
+
+- Lists work too
+
+</Note>
+````
+
+### When indentJsxContent is safe
+
+This option works well for components whose children are **not parsed as markdown** — for example, layout wrappers that contain other JSX components rather than prose:
+
+````markdown
+<LayoutDivide>
+
+  <LayoutDivideItem>
+    Content here
+  </LayoutDivideItem>
+
+  <LayoutDivideItem>
+    Content here
+  </LayoutDivideItem>
+
+</LayoutDivide>
+````


### PR DESCRIPTION
## Summary

Document the recommended usage and cautions for `addEmptyLinesInBlockJsx` and `indentJsxContent` when working with admonition-style components that contain markdown content.

## Changes

### addEmptyLinesInBlockJsx
- Added "Admonition-like components" section explaining why this is the recommended option for `<Note>`, `<Warning>`, `<Danger>`, etc.
- Explains that blank lines after opening tags are **required** for MDX parsers to treat content as markdown
- Added cross-reference to indentJsxContent caution

### indentJsxContent
- Added "Caution with markdown content" section warning against using on admonition components
- Explains the 4-space code block problem: indented markdown gets misinterpreted as code blocks
- Added "What to use instead" pointing to addEmptyLinesInBlockJsx
- Added "When indentJsxContent is safe" — layout wrappers with JSX children, not prose

## Context

When setting up auto-formatting for a documentation site (zudo-doc), both options were applied to admonitions (`<Note>`, `<Warning>`, etc.) and tab components (`<Tabs>`, `<TabItem>`). This caused:
1. `indentJsxContent` broke markdown rendering inside admonitions
2. Applying both options to the same components triggered operation conflicts (fixed in PR #11)

These docs clarify the intended use case for each option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)