### PR TITLE
Rust migration: HTML block formatter replacing Prettier

### DIFF
--- a/crates/mdx-formatter-core/src/formatter.rs
+++ b/crates/mdx-formatter-core/src/formatter.rs
@@ -1,3 +1,4 @@
+use crate::html_formatter;
 use crate::parser;
 use crate::types::{FormatterOperation, FormatterSettings, FormatYamlFrontmatterSetting};
 use markdown::mdast::{
@@ -99,6 +100,11 @@ fn format_once(content: &str, settings: &FormatterSettings) -> String {
     }
 
     collect_list_indentation_operations(&ast, &lines, &mut operations);
+
+    // HTML block formatting
+    if settings.format_html_blocks_in_mdx.enabled {
+        collect_html_block_operations(&ast, &lines, &mut operations);
+    }
 
     // 4. Filter overlapping replacements
     filter_overlapping_replacements(&mut operations);
@@ -1070,6 +1076,91 @@ fn is_ordered_list_marker(trimmed: &str) -> bool {
 fn is_numbered_list_line(line: &str) -> bool {
     let trimmed = line.trim();
     is_ordered_list_marker(trimmed)
+}
+
+// ============================================================================
+// HTML Block Formatting
+// ============================================================================
+
+/// Walk the AST for MdxJsxFlowElement nodes with lowercase tag names (HTML elements).
+/// For each top-level HTML block, format it and emit a ReplaceHtmlBlock operation
+/// if the formatted content differs from the original.
+fn collect_html_block_operations(
+    node: &Node,
+    lines: &[&str],
+    operations: &mut Vec<FormatterOperation>,
+) {
+    let mut html_nodes: Vec<(usize, usize)> = Vec::new(); // (start_line_0, end_line_0)
+    let mut processed_ranges: Vec<(usize, usize)> = Vec::new();
+
+    // Walk AST to find top-level HTML flow elements
+    collect_html_flow_elements(node, &mut html_nodes, &mut processed_ranges);
+
+    // Process each top-level HTML node
+    for (start_line, end_line) in html_nodes {
+        if start_line >= lines.len() || end_line >= lines.len() {
+            continue;
+        }
+
+        // Extract the HTML content from source lines
+        let html_lines: Vec<&str> = lines[start_line..=end_line].to_vec();
+        let html_content = html_lines.join("\n");
+
+        // Format the HTML block
+        let formatted = html_formatter::format_html_block(&html_content, 2);
+
+        // Only emit operation if formatting changed the content
+        if formatted != html_content {
+            operations.push(FormatterOperation::ReplaceHtmlBlock {
+                start_line,
+                end_line,
+                content: formatted,
+            });
+        }
+    }
+}
+
+/// Recursively walk AST to find MdxJsxFlowElement nodes with lowercase names.
+/// Only collects top-level HTML blocks (skips nodes nested inside already-processed ranges).
+fn collect_html_flow_elements(
+    node: &Node,
+    results: &mut Vec<(usize, usize)>,
+    processed_ranges: &mut Vec<(usize, usize)>,
+) {
+    match node {
+        Node::MdxJsxFlowElement(jsx) => {
+            if let Some(name) = &jsx.name {
+                if is_html_element(name) {
+                    if let Some(pos) = &jsx.position {
+                        let start_line = pos.start.line - 1; // 0-indexed
+                        let end_line = pos.end.line - 1;
+
+                        // Check if this node is nested inside an already-processed range
+                        let is_nested = processed_ranges
+                            .iter()
+                            .any(|&(rs, re)| start_line > rs && end_line < re);
+
+                        if !is_nested {
+                            results.push((start_line, end_line));
+                            processed_ranges.push((start_line, end_line));
+                        }
+
+                        // Don't recurse into children — they're part of this block
+                        return;
+                    }
+                }
+            }
+            // If not an HTML element, recurse into children
+            for child in &jsx.children {
+                collect_html_flow_elements(child, results, processed_ranges);
+            }
+        }
+        _ => {
+            for child in get_children(node) {
+                collect_html_flow_elements(child, results, processed_ranges);
+            }
+        }
+    }
 }
 
 /// Pre-process YAML text to quote values containing special YAML characters.

--- a/crates/mdx-formatter-core/src/html_formatter.rs
+++ b/crates/mdx-formatter-core/src/html_formatter.rs
@@ -1,0 +1,354 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Void HTML elements that never have a closing tag.
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+    "source", "track", "wbr",
+];
+
+/// Regex to match an opening HTML tag at the start of a trimmed line.
+/// Captures: (1) tag name, (2) rest including attributes and closing bracket.
+static OPENING_TAG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^<([a-zA-Z][a-zA-Z0-9]*)(\s[^>]*)?>").unwrap());
+
+/// Regex to match a closing HTML tag at the start of a trimmed line.
+/// Captures: (1) tag name.
+static CLOSING_TAG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^</([a-zA-Z][a-zA-Z0-9]*)>").unwrap());
+
+/// Regex to match a self-closing tag (e.g. `<br />`, `<img ... />`).
+static SELF_CLOSING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^<([a-zA-Z][a-zA-Z0-9]*)(\s[^>]*)?\s*/>").unwrap());
+
+/// Regex to collapse whitespace inside `<dt>...</dt>` tags (single-line after collapse).
+/// Only matches dt tags whose content has no nested HTML tags (no `<` in content).
+static DT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<dt>([^<]*)</dt>").unwrap());
+
+/// Regex to collapse whitespace inside `<dd>...</dd>` tags (single-line after collapse).
+/// Only matches dd tags whose content has no nested HTML tags (no `<` in content).
+static DD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<dd>([^<]*)</dd>").unwrap());
+
+/// Check if a tag name is a void element.
+fn is_void_element(tag: &str) -> bool {
+    VOID_ELEMENTS.contains(&tag.to_ascii_lowercase().as_str())
+}
+
+/// Format an HTML block with proper indentation.
+///
+/// Algorithm:
+/// 1. Pre-process: collapse whitespace inside `<dt>` and `<dd>` tags.
+/// 2. Split into lines, trim each.
+/// 3. For each line, detect tags and adjust indent depth.
+/// 4. Reconstruct with proper indentation.
+pub fn format_html_block(html: &str, indent_size: usize) -> String {
+    // Guard: skip formatting if input contains multi-line tags (opening tag
+    // split across lines). The line-based formatter can't handle these correctly.
+    if has_multiline_tags(html) {
+        return html.to_string();
+    }
+
+    // Step 1: Pre-process dt/dd — collapse internal whitespace to single-line
+    let preprocessed = preprocess_dt_dd(html);
+
+    // Step 2: Split into lines and trim
+    let raw_lines: Vec<&str> = preprocessed.split('\n').collect();
+
+    // Step 3: Re-indent based on tag nesting
+    let mut result_lines: Vec<String> = Vec::new();
+    let mut depth: i32 = 0;
+
+    for raw_line in &raw_lines {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            result_lines.push(String::new());
+            continue;
+        }
+
+        // Calculate depth adjustments for this line
+        let (depth_before, depth_after) = compute_depth_changes(trimmed);
+
+        // Apply "before" adjustment (closing tags reduce depth before indenting)
+        depth += depth_before;
+        if depth < 0 {
+            depth = 0;
+        }
+
+        // Build indented line
+        let indent = " ".repeat((depth as usize) * indent_size);
+        result_lines.push(format!("{}{}", indent, trimmed));
+
+        // Apply "after" adjustment (opening tags increase depth after this line)
+        depth += depth_after;
+        if depth < 0 {
+            depth = 0;
+        }
+    }
+
+    // Step 4: Post-process — trim content inside dt/dd tags
+    let result = result_lines.join("\n");
+    postprocess_dt_dd(&result)
+}
+
+/// Check if the HTML contains multi-line tags (opening tag where `<tagname`
+/// appears on one line but the closing `>` is on a subsequent line).
+fn has_multiline_tags(html: &str) -> bool {
+    for line in html.split('\n') {
+        let trimmed = line.trim();
+        // Check if line starts with `<tagname` but doesn't contain `>` (split tag)
+        if let Some(m) = OPENING_TAG_START_RE.find(trimmed) {
+            // If we matched `<tagname` at position 0, check if there's a `>` on this line
+            let after_tag = &trimmed[m.end()..];
+            if !after_tag.contains('>') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Regex to detect start of an opening tag (no closing bracket required).
+static OPENING_TAG_START_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^<[a-zA-Z][a-zA-Z0-9]*").unwrap());
+
+/// Pre-process: collapse whitespace inside `<dt>` and `<dd>` tags so their
+/// content becomes a single line. This matches the TS formatter behavior.
+fn preprocess_dt_dd(html: &str) -> String {
+    let result = DT_RE.replace_all(html, |caps: &regex::Captures| {
+        let content = &caps[1];
+        let cleaned = collapse_whitespace(content);
+        format!("<dt>{}</dt>", cleaned)
+    });
+    let result = DD_RE.replace_all(&result, |caps: &regex::Captures| {
+        let content = &caps[1];
+        let cleaned = collapse_whitespace(content);
+        format!("<dd>{}</dd>", cleaned)
+    });
+    result.into_owned()
+}
+
+/// Post-process: trim whitespace inside dt/dd tags.
+fn postprocess_dt_dd(html: &str) -> String {
+    let re = Regex::new(r"<(dt|dd)>\s*(.*?)\s*</(dt|dd)>").unwrap();
+    re.replace_all(html, "<$1>$2</$3>").into_owned()
+}
+
+/// Collapse multiple whitespace characters (including newlines) into a single space, then trim.
+fn collapse_whitespace(s: &str) -> String {
+    let re = Regex::new(r"\s+").unwrap();
+    re.replace_all(s, " ").trim().to_string()
+}
+
+/// Compute depth changes for a single line.
+///
+/// Returns `(depth_before, depth_after)`:
+/// - `depth_before`: adjustment to apply BEFORE indenting this line
+///   (negative for closing tags at line start that reduce this line's indent)
+/// - `depth_after`: adjustment to apply AFTER indenting this line
+///   (positive for opening tags that increase indent for subsequent lines)
+///
+/// Uses a sequential scan: tracks a running `delta` through all tags.
+/// The minimum delta seen determines how much to un-indent this line (`before`).
+/// The remaining net change applies to subsequent lines (`after`).
+fn compute_depth_changes(line: &str) -> (i32, i32) {
+    let mut delta: i32 = 0;
+    let mut min_delta: i32 = 0;
+    let mut pos = 0;
+    let bytes = line.as_bytes();
+
+    while pos < bytes.len() {
+        if bytes[pos] != b'<' {
+            pos += 1;
+            continue;
+        }
+
+        let remaining = &line[pos..];
+
+        // Try self-closing tag first (e.g., <br />, <img ... />)
+        if let Some(m) = SELF_CLOSING_RE.find(remaining) {
+            pos += m.end();
+            continue;
+        }
+
+        // Try closing tag (e.g., </div>)
+        if let Some(caps) = CLOSING_TAG_RE.captures(remaining) {
+            delta -= 1;
+            if delta < min_delta {
+                min_delta = delta;
+            }
+            pos += caps[0].len();
+            continue;
+        }
+
+        // Try opening tag (e.g., <div>, <table class="...">)
+        if let Some(caps) = OPENING_TAG_RE.captures(remaining) {
+            let tag = &caps[1];
+            if !is_void_element(tag) {
+                delta += 1;
+            }
+            pos += caps[0].len();
+            continue;
+        }
+
+        pos += 1;
+    }
+
+    // min_delta: the lowest point reached by closing tags (≤ 0)
+    //   → this is how much to reduce indent BEFORE this line
+    // delta - min_delta: remaining net increase from opening tags
+    //   → this increases indent AFTER this line
+    (min_delta, delta - min_delta)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_dl() {
+        let input = "<dl>\n<dt>Term 1</dt>\n<dd>Definition 1</dd>\n</dl>";
+        let expected = "<dl>\n  <dt>Term 1</dt>\n  <dd>Definition 1</dd>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_dl_with_excessive_whitespace() {
+        let input = "<dl>\n  <dt>  Term with spaces  </dt>\n  <dd>   Definition with spaces   </dd>\n</dl>";
+        let expected = "<dl>\n  <dt>Term with spaces</dt>\n  <dd>Definition with spaces</dd>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_dl_with_div_wrappers() {
+        let input = "<dl>\n<div>\n<dt>Term 1</dt>\n<dd>Definition 1</dd>\n</div>\n<div>\n<dt>Term 2</dt>\n<dd>Definition 2</dd>\n</div>\n</dl>";
+        let expected = "<dl>\n  <div>\n    <dt>Term 1</dt>\n    <dd>Definition 1</dd>\n  </div>\n  <div>\n    <dt>Term 2</dt>\n    <dd>Definition 2</dd>\n  </div>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_nested_definition_lists() {
+        let input = "<dl>\n<dt>Outer Term</dt>\n<dd>\n<dl>\n<dt>Inner Term</dt>\n<dd>Inner Definition</dd>\n</dl>\n</dd>\n</dl>";
+        let expected = "<dl>\n  <dt>Outer Term</dt>\n  <dd>\n    <dl>\n      <dt>Inner Term</dt>\n      <dd>Inner Definition</dd>\n    </dl>\n  </dd>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_simple_table() {
+        let input = "<table>\n<tr>\n<td>Cell 1</td>\n<td>Cell 2</td>\n</tr>\n<tr>\n<td>Cell 3</td>\n<td>Cell 4</td>\n</tr>\n</table>";
+        let expected = "<table>\n  <tr>\n    <td>Cell 1</td>\n    <td>Cell 2</td>\n  </tr>\n  <tr>\n    <td>Cell 3</td>\n    <td>Cell 4</td>\n  </tr>\n</table>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_table_with_thead_tbody() {
+        let input = "<table>\n<thead>\n<tr>\n<th>Header 1</th>\n<th>Header 2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Data 1</td>\n<td>Data 2</td>\n</tr>\n</tbody>\n</table>";
+        let expected = "<table>\n  <thead>\n    <tr>\n      <th>Header 1</th>\n      <th>Header 2</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Data 1</td>\n      <td>Data 2</td>\n    </tr>\n  </tbody>\n</table>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_table_with_attributes() {
+        let input = "<table class=\"data-table\" id=\"results\">\n<tr class=\"row-highlight\">\n<td colspan=\"2\">Merged Cell</td>\n</tr>\n</table>";
+        let expected = "<table class=\"data-table\" id=\"results\">\n  <tr class=\"row-highlight\">\n    <td colspan=\"2\">Merged Cell</td>\n  </tr>\n</table>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_unordered_list() {
+        let input = "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n<li>Item 3</li>\n</ul>";
+        let expected = "<ul>\n  <li>Item 1</li>\n  <li>Item 2</li>\n  <li>Item 3</li>\n</ul>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_ordered_list() {
+        let input = "<ol>\n<li>First</li>\n<li>Second</li>\n<li>Third</li>\n</ol>";
+        let expected = "<ol>\n  <li>First</li>\n  <li>Second</li>\n  <li>Third</li>\n</ol>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_nested_divs() {
+        let input = "<div class=\"container\">\n<div class=\"row\">\n<div class=\"col\">Content</div>\n</div>\n</div>";
+        let expected = "<div class=\"container\">\n  <div class=\"row\">\n    <div class=\"col\">Content</div>\n  </div>\n</div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_div_with_mixed_content() {
+        let input = "<div>\n<h3>Title</h3>\n<p>Paragraph text here.</p>\n<ul>\n<li>List item</li>\n</ul>\n</div>";
+        let expected = "<div>\n  <h3>Title</h3>\n  <p>Paragraph text here.</p>\n  <ul>\n    <li>List item</li>\n  </ul>\n</div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_select_options() {
+        let input = "<select name=\"choice\">\n<option value=\"1\">Option 1</option>\n<option value=\"2\">Option 2</option>\n<option value=\"3\">Option 3</option>\n</select>";
+        let expected = "<select name=\"choice\">\n  <option value=\"1\">Option 1</option>\n  <option value=\"2\">Option 2</option>\n  <option value=\"3\">Option 3</option>\n</select>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_empty_elements() {
+        // Single-line empty elements should remain unchanged
+        let input = "<div></div>";
+        let expected = "<div></div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_self_closing_void_elements() {
+        let input = "<div>\n<img src=\"image.jpg\" alt=\"Test\" />\n<br />\n<hr />\n</div>";
+        let expected = "<div>\n  <img src=\"image.jpg\" alt=\"Test\" />\n  <br />\n  <hr />\n</div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_deeply_nested() {
+        let input = "<div>\n<section>\n<article>\n<header>\n<h1>Title</h1>\n</header>\n<main>\n<p>Content</p>\n</main>\n<footer>\n<p>Footer</p>\n</footer>\n</article>\n</section>\n</div>";
+        let expected = "<div>\n  <section>\n    <article>\n      <header>\n        <h1>Title</h1>\n      </header>\n      <main>\n        <p>Content</p>\n      </main>\n      <footer>\n        <p>Footer</p>\n      </footer>\n    </article>\n  </section>\n</div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_long_attributes_no_wrapping() {
+        let input = "<div class=\"very-long-class-name\" id=\"very-long-id\" data-attribute=\"very-long-value\">\n<p>Content</p>\n</div>";
+        let expected = "<div class=\"very-long-class-name\" id=\"very-long-id\" data-attribute=\"very-long-value\">\n  <p>Content</p>\n</div>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_already_formatted() {
+        // Input that's already properly indented should not change
+        let input = "<dl>\n  <dt>Term</dt>\n  <dd>Definition</dd>\n</dl>";
+        let expected = "<dl>\n  <dt>Term</dt>\n  <dd>Definition</dd>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_dt_dd_multiline_collapse() {
+        // Multi-line dt/dd content should be collapsed to single line
+        let input = "<dl>\n<dt>\n  Term across\n  multiple lines\n</dt>\n<dd>\n  Definition across\n  lines\n</dd>\n</dl>";
+        let expected = "<dl>\n  <dt>Term across multiple lines</dt>\n  <dd>Definition across lines</dd>\n</dl>";
+        assert_eq!(format_html_block(input, 2), expected);
+    }
+
+    #[test]
+    fn test_inline_span_elements() {
+        let input = "<div>\n<span class=\"highlight\">Important</span> text with <span>inline</span> elements.\n</div>";
+        let result = format_html_block(input, 2);
+        assert!(result.contains("Important"));
+        assert!(result.contains("inline"));
+    }
+
+    #[test]
+    fn test_div_with_markdown_content() {
+        let input = "<div>\n**Bold text** and *italic text* within HTML.\n[Link](https://example.com) in a div.\n</div>";
+        let result = format_html_block(input, 2);
+        assert!(result.contains("Bold text"));
+        assert!(result.contains("italic text"));
+        assert!(result.contains("https://example.com"));
+    }
+}

--- a/crates/mdx-formatter-core/src/lib.rs
+++ b/crates/mdx-formatter-core/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod formatter;
+pub mod html_formatter;
 pub mod parser;
 pub mod types;
 
 pub use formatter::format;
+pub use html_formatter::format_html_block;
 pub use types::FormatterSettings;

--- a/crates/mdx-formatter-core/tests/cross_platform.rs
+++ b/crates/mdx-formatter-core/tests/cross_platform.rs
@@ -12,6 +12,7 @@
 //! - JSX multi-line formatting (attribute indentation, self-closing fix, block JSX empty lines)
 //! - YAML frontmatter formatting (parse, reformat, unsafe value quoting)
 //! - List indentation normalization
+//! - HTML block formatting (indentation of HTML elements in MDX)
 //! - Convergence loop (max 3 iterations)
 //! - Empty line normalization (collapse 3+ newlines to 2)
 
@@ -1294,4 +1295,176 @@ fn stress_frontmatter_jsx_lists_code() {
     let input = "---\ntitle: Complex\n---\n\n# Title\n\nIntro text.\n\n<Widget type=\"fancy\" />\n\n- Item 1\n- Item 2\n\n```ts\nconst x = 1;\n```\n\n## Conclusion\n\nFinal words.";
     let result = format(input, &default_settings());
     assert_eq!(result, input, "Well-structured document should be stable");
+}
+
+// ============================================================================
+// HTML Block Formatting (from html-blocks.test.ts)
+// ============================================================================
+
+#[test]
+fn html_block_simple_dl() {
+    let input = "<dl>\n<dt>Term 1</dt>\n<dd>Definition 1</dd>\n</dl>";
+    let expected = "<dl>\n  <dt>Term 1</dt>\n  <dd>Definition 1</dd>\n</dl>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_dl_excessive_whitespace() {
+    let input = "<dl>\n  <dt>  Term with spaces  </dt>\n  <dd>   Definition with spaces   </dd>\n</dl>";
+    let expected = "<dl>\n  <dt>Term with spaces</dt>\n  <dd>Definition with spaces</dd>\n</dl>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_dl_with_div_wrappers() {
+    let input = "<dl>\n<div>\n<dt>Term 1</dt>\n<dd>Definition 1</dd>\n</div>\n<div>\n<dt>Term 2</dt>\n<dd>Definition 2</dd>\n</div>\n</dl>";
+    let expected = "<dl>\n  <div>\n    <dt>Term 1</dt>\n    <dd>Definition 1</dd>\n  </div>\n  <div>\n    <dt>Term 2</dt>\n    <dd>Definition 2</dd>\n  </div>\n</dl>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_nested_definition_lists() {
+    let input = "<dl>\n<dt>Outer Term</dt>\n<dd>\n<dl>\n<dt>Inner Term</dt>\n<dd>Inner Definition</dd>\n</dl>\n</dd>\n</dl>";
+    let expected = "<dl>\n  <dt>Outer Term</dt>\n  <dd>\n    <dl>\n      <dt>Inner Term</dt>\n      <dd>Inner Definition</dd>\n    </dl>\n  </dd>\n</dl>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_simple_table() {
+    let input = "<table>\n<tr>\n<td>Cell 1</td>\n<td>Cell 2</td>\n</tr>\n<tr>\n<td>Cell 3</td>\n<td>Cell 4</td>\n</tr>\n</table>";
+    let expected = "<table>\n  <tr>\n    <td>Cell 1</td>\n    <td>Cell 2</td>\n  </tr>\n  <tr>\n    <td>Cell 3</td>\n    <td>Cell 4</td>\n  </tr>\n</table>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_table_with_thead_tbody() {
+    let input = "<table>\n<thead>\n<tr>\n<th>Header 1</th>\n<th>Header 2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Data 1</td>\n<td>Data 2</td>\n</tr>\n</tbody>\n</table>";
+    let expected = "<table>\n  <thead>\n    <tr>\n      <th>Header 1</th>\n      <th>Header 2</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Data 1</td>\n      <td>Data 2</td>\n    </tr>\n  </tbody>\n</table>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_table_with_attributes() {
+    let input = "<table class=\"data-table\" id=\"results\">\n<tr class=\"row-highlight\">\n<td colspan=\"2\">Merged Cell</td>\n</tr>\n</table>";
+    let expected = "<table class=\"data-table\" id=\"results\">\n  <tr class=\"row-highlight\">\n    <td colspan=\"2\">Merged Cell</td>\n  </tr>\n</table>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_unordered_list() {
+    let input = "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n<li>Item 3</li>\n</ul>";
+    let expected = "<ul>\n  <li>Item 1</li>\n  <li>Item 2</li>\n  <li>Item 3</li>\n</ul>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_ordered_list() {
+    let input = "<ol>\n<li>First</li>\n<li>Second</li>\n<li>Third</li>\n</ol>";
+    let expected = "<ol>\n  <li>First</li>\n  <li>Second</li>\n  <li>Third</li>\n</ol>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_nested_divs() {
+    let input = "<div class=\"container\">\n<div class=\"row\">\n<div class=\"col\">Content</div>\n</div>\n</div>";
+    let expected = "<div class=\"container\">\n  <div class=\"row\">\n    <div class=\"col\">Content</div>\n  </div>\n</div>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_div_with_mixed_content() {
+    let input = "<div>\n<h3>Title</h3>\n<p>Paragraph text here.</p>\n<ul>\n<li>List item</li>\n</ul>\n</div>";
+    let expected = "<div>\n  <h3>Title</h3>\n  <p>Paragraph text here.</p>\n  <ul>\n    <li>List item</li>\n  </ul>\n</div>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_select_options() {
+    let input = "<select name=\"choice\">\n<option value=\"1\">Option 1</option>\n<option value=\"2\">Option 2</option>\n<option value=\"3\">Option 3</option>\n</select>";
+    let expected = "<select name=\"choice\">\n  <option value=\"1\">Option 1</option>\n  <option value=\"2\">Option 2</option>\n  <option value=\"3\">Option 3</option>\n</select>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_mixed_mdx_content() {
+    let input = "# Heading\n\nSome paragraph text.\n\n<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>\n\nMore content here.\n\n<table>\n<tr>\n<td>Data</td>\n</tr>\n</table>";
+    let expected = "# Heading\n\nSome paragraph text.\n\n<dl>\n  <dt>Term</dt>\n  <dd>Definition</dd>\n</dl>\n\nMore content here.\n\n<table>\n  <tr>\n    <td>Data</td>\n  </tr>\n</table>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_empty_elements() {
+    let input = "<div></div>\n<span></span>\n<p></p>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, input);
+}
+
+#[test]
+fn html_block_self_closing_void_elements() {
+    let input = "<div>\n<img src=\"image.jpg\" alt=\"Test\" />\n<br />\n<hr />\n</div>";
+    let expected = "<div>\n  <img src=\"image.jpg\" alt=\"Test\" />\n  <br />\n  <hr />\n</div>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_deeply_nested() {
+    let input = "<div>\n<section>\n<article>\n<header>\n<h1>Title</h1>\n</header>\n<main>\n<p>Content</p>\n</main>\n<footer>\n<p>Footer</p>\n</footer>\n</article>\n</section>\n</div>";
+    let expected = "<div>\n  <section>\n    <article>\n      <header>\n        <h1>Title</h1>\n      </header>\n      <main>\n        <p>Content</p>\n      </main>\n      <footer>\n        <p>Footer</p>\n      </footer>\n    </article>\n  </section>\n</div>";
+    let result = format(input, &default_settings());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn html_block_disabled_setting() {
+    let input = "<dl>\n<dt>Term</dt>\n<dd>Definition</dd>\n</dl>";
+    let mut settings = default_settings();
+    settings.format_html_blocks_in_mdx.enabled = false;
+    let result = format(input, &settings);
+    assert_eq!(result, input, "Should not change when disabled");
+}
+
+#[test]
+fn html_block_long_attributes_no_wrapping() {
+    let input = "<div class=\"very-long-class-name-that-exceeds-normal-width\" id=\"very-long-id-value\" data-attribute=\"very-long-attribute-value\">\n<p>Content</p>\n</div>";
+    let result = format(input, &default_settings());
+    assert!(result.contains("very-long-class-name-that-exceeds-normal-width"));
+    assert!(result.contains("<p>Content</p>"));
+}
+
+#[test]
+fn html_block_backward_compat_trimmed_dt_dd() {
+    let input = "<dl>\n  <dt>  Term with spaces  </dt>\n  <dd>   Definition with spaces   </dd>\n</dl>";
+    let result = format(input, &default_settings());
+    assert!(result.contains("<dt>Term with spaces</dt>"));
+    assert!(result.contains("<dd>Definition with spaces</dd>"));
+}
+
+#[test]
+fn html_block_idempotent() {
+    // Formatting already-formatted HTML should produce the same output
+    let formatted = "<dl>\n  <dt>Term</dt>\n  <dd>Definition</dd>\n</dl>";
+    let result = format(formatted, &default_settings());
+    assert_eq!(result, formatted, "HTML block formatting should be idempotent");
+}
+
+#[test]
+fn html_block_inline_span_preserves_content() {
+    let input = "<div>\n<span class=\"highlight\">Important</span> text with <span>inline</span> elements.\n</div>";
+    let result = format(input, &default_settings());
+    assert!(result.contains("Important"));
+    assert!(result.contains("inline"));
 }

--- a/test/rust-passthrough.test.ts
+++ b/test/rust-passthrough.test.ts
@@ -4,7 +4,7 @@
  * Runs the same test cases from formatter.test.ts against the Rust napi
  * formatter to measure the gap between TS and Rust implementations.
  *
- * HTML block tests are skipped — not yet implemented in Rust.
+ * Now includes HTML block formatting tests.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -45,7 +45,307 @@ describe.skipIf(!rustAvailable)('Rust Passthrough: Markdown Formatter', () => {
     });
   });
 
-  // HTML Definition List Formatting — SKIPPED (HTML blocks not implemented in Rust)
+  describe('HTML Block Formatting', () => {
+    it('should format simple dl/dt/dd with proper indentation', async () => {
+      const input = `<dl>
+<dt>Term 1</dt>
+<dd>Definition 1</dd>
+</dl>`;
+      const expected = `<dl>
+  <dt>Term 1</dt>
+  <dd>Definition 1</dd>
+</dl>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle dl/dt/dd with excessive whitespace', async () => {
+      const input = `<dl>
+  <dt>  Term with spaces  </dt>
+  <dd>   Definition with spaces   </dd>
+</dl>`;
+      const expected = `<dl>
+  <dt>Term with spaces</dt>
+  <dd>Definition with spaces</dd>
+</dl>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format dl with div wrappers', async () => {
+      const input = `<dl>
+<div>
+<dt>Term 1</dt>
+<dd>Definition 1</dd>
+</div>
+<div>
+<dt>Term 2</dt>
+<dd>Definition 2</dd>
+</div>
+</dl>`;
+      const expected = `<dl>
+  <div>
+    <dt>Term 1</dt>
+    <dd>Definition 1</dd>
+  </div>
+  <div>
+    <dt>Term 2</dt>
+    <dd>Definition 2</dd>
+  </div>
+</dl>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle nested definition lists', async () => {
+      const input = `<dl>
+<dt>Outer Term</dt>
+<dd>
+<dl>
+<dt>Inner Term</dt>
+<dd>Inner Definition</dd>
+</dl>
+</dd>
+</dl>`;
+      const expected = `<dl>
+  <dt>Outer Term</dt>
+  <dd>
+    <dl>
+      <dt>Inner Term</dt>
+      <dd>Inner Definition</dd>
+    </dl>
+  </dd>
+</dl>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format simple table structure', async () => {
+      const input = `<table>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td>Cell 3</td>
+<td>Cell 4</td>
+</tr>
+</table>`;
+      const expected = `<table>
+  <tr>
+    <td>Cell 1</td>
+    <td>Cell 2</td>
+  </tr>
+  <tr>
+    <td>Cell 3</td>
+    <td>Cell 4</td>
+  </tr>
+</table>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format table with thead and tbody', async () => {
+      const input = `<table>
+<thead>
+<tr>
+<th>Header 1</th>
+<th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Data 1</td>
+<td>Data 2</td>
+</tr>
+</tbody>
+</table>`;
+      const expected = `<table>
+  <thead>
+    <tr>
+      <th>Header 1</th>
+      <th>Header 2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Data 1</td>
+      <td>Data 2</td>
+    </tr>
+  </tbody>
+</table>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format unordered list', async () => {
+      const input = `<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+<li>Item 3</li>
+</ul>`;
+      const expected = `<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
+</ul>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format nested div elements', async () => {
+      const input = `<div class="container">
+<div class="row">
+<div class="col">Content</div>
+</div>
+</div>`;
+      const expected = `<div class="container">
+  <div class="row">
+    <div class="col">Content</div>
+  </div>
+</div>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format div with mixed content', async () => {
+      const input = `<div>
+<h3>Title</h3>
+<p>Paragraph text here.</p>
+<ul>
+<li>List item</li>
+</ul>
+</div>`;
+      const expected = `<div>
+  <h3>Title</h3>
+  <p>Paragraph text here.</p>
+  <ul>
+    <li>List item</li>
+  </ul>
+</div>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle select and options', async () => {
+      const input = `<select name="choice">
+<option value="1">Option 1</option>
+<option value="2">Option 2</option>
+<option value="3">Option 3</option>
+</select>`;
+      const expected = `<select name="choice">
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+  <option value="3">Option 3</option>
+</select>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should format HTML blocks within MDX content', async () => {
+      const input = `# Heading
+
+Some paragraph text.
+
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+
+More content here.
+
+<table>
+<tr>
+<td>Data</td>
+</tr>
+</table>`;
+      const expected = `# Heading
+
+Some paragraph text.
+
+<dl>
+  <dt>Term</dt>
+  <dd>Definition</dd>
+</dl>
+
+More content here.
+
+<table>
+  <tr>
+    <td>Data</td>
+  </tr>
+</table>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle empty HTML elements', async () => {
+      const input = `<div></div>
+<span></span>
+<p></p>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(input);
+    });
+
+    it('should preserve self-closing tags', async () => {
+      const input = `<div>
+<img src="image.jpg" alt="Test" />
+<br />
+<hr />
+</div>`;
+      const expected = `<div>
+  <img src="image.jpg" alt="Test" />
+  <br />
+  <hr />
+</div>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should handle deeply nested structures', async () => {
+      const input = `<div>
+<section>
+<article>
+<header>
+<h1>Title</h1>
+</header>
+<main>
+<p>Content</p>
+</main>
+<footer>
+<p>Footer</p>
+</footer>
+</article>
+</section>
+</div>`;
+      const expected = `<div>
+  <section>
+    <article>
+      <header>
+        <h1>Title</h1>
+      </header>
+      <main>
+        <p>Content</p>
+      </main>
+      <footer>
+        <p>Footer</p>
+      </footer>
+    </article>
+  </section>
+</div>`;
+      const result = await format(input, { settings: testSettings });
+      expect(result).toBe(expected);
+    });
+
+    it('should be idempotent', async () => {
+      const formatted = `<dl>
+  <dt>Term</dt>
+  <dd>Definition</dd>
+</dl>`;
+      const result = await format(formatted, { settings: testSettings });
+      expect(result).toBe(formatted);
+    });
+  });
 
   describe('MDX/JSX Support', () => {
     it('should handle JSX components with empty lines', async () => {
@@ -627,9 +927,9 @@ Another paragraph.`;
       });
     });
 
-    // Issue 3: dl/dt/dd with div wrapper formatting — SKIPPED (HTML blocks not implemented in Rust)
+    // Issue 3: dl/dt/dd with div wrapper formatting — now covered in HTML Block Formatting section
 
-    // Combined scenarios — SKIPPED (includes dl/dt/dd HTML block tests)
+    // Combined scenarios — dl/dt/dd tests now covered in HTML Block Formatting section
   });
 
   describe('Issue #27: Paragraph/list spacing in production formatter', () => {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/mdx-formatter/issues/29

---

## Summary
- Implement a minimal HTML block indentation formatter in Rust, replacing the Prettier-based approach from TypeScript
- Wire HTML formatter into the Rust formatter pipeline via `collect_html_block_operations()`
- Add 41 new Rust tests for HTML formatting + 15 new TS passthrough tests
- **85/85 TS passthrough tests now pass** (up from 70)

## Changes

### New module: `html_formatter.rs`
- `format_html_block()` — normalizes HTML indentation by tracking tag nesting depth
- Pre-processes `<dt>`/`<dd>` content (collapses whitespace to single line)
- Handles void elements (br, hr, img, input, etc.) — no depth change
- Post-processes: trims dt/dd content, handles self-closing tags

### Integration in `formatter.rs`
- `collect_html_block_operations()` — walks AST for lowercase MdxJsxFlowElement nodes (HTML elements)
- Skips nested HTML blocks (parent format includes children)
- Emits `ReplaceHtmlBlock` operations for blocks that changed
- Gated on `settings.format_html_blocks_in_mdx.enabled`

### Tests
- 41 new Rust unit tests in `html_formatter.rs` covering:
  - Basic dl/dt/dd formatting, nested div indentation, void elements
  - Whitespace trimming, already-formatted preservation, edge cases
- 21 cross-platform tests ported from `test/html-blocks.test.ts`
- 15 new TS passthrough tests for HTML blocks

## Test Plan
- 315 Rust cargo tests pass (was 274)
- 207 TS tests pass (no regressions)
- 29 Rust-specific TS tests pass
- 85 passthrough tests pass (was 70)
- CI green on Node 18, 20, 22