### PR TITLE
Update Rust migration docs to reflect current status

### DIFF
--- a/RUST_REWRITE.md
+++ b/RUST_REWRITE.md
@@ -1,17 +1,18 @@
-# Rust Rewrite - Proof of Concept
+# Rust Rewrite
 
-This document describes the experimental Rust rewrite of mdx-formatter using markdown-rs for AST parsing and napi-rs for Node.js bindings.
+The Rust implementation of mdx-formatter reimplements the full formatting engine using markdown-rs for AST parsing and napi-rs for Node.js bindings. All formatting rules from the TypeScript version are implemented and tested.
 
 ## Architecture
 
 ```
 Rust Core (mdx-formatter-core)
-├── parser.rs     - markdown-rs integration (mdast parsing)
-├── formatter.rs  - Hybrid formatter (AST analysis → line operations)
-└── types.rs      - Settings, operations, type definitions
+├── parser.rs          - markdown-rs integration (mdast parsing)
+├── formatter.rs       - Hybrid formatter (AST analysis → line operations)
+├── html_formatter.rs  - HTML block indentation formatter
+└── types.rs           - Settings, operations, type definitions
 
 napi-rs Bridge (mdx-formatter-napi)
-└── lib.rs        - Node.js native bindings
+└── lib.rs             - Node.js native bindings
 
 TypeScript Bridge
 └── src/rust-formatter.ts  - JS wrapper that loads native module
@@ -24,7 +25,8 @@ The Rust formatter uses the same hybrid approach as the TypeScript implementatio
 1. Parse markdown/MDX into an mdast AST using `markdown-rs`
 2. Analyze the AST to collect line-based formatting operations
 3. Apply operations to the original source lines (not AST round-trip)
-4. Run convergence loop (max 3 iterations) until output stabilizes
+4. Post-process: ensure block-level spacing between elements
+5. Run convergence loop (max 3 iterations) until output stabilizes
 
 ## Prerequisites
 
@@ -35,55 +37,57 @@ The Rust formatter uses the same hybrid approach as the TypeScript implementatio
 ## Building
 
 ```bash
-# Build the Rust formatter
-cargo build
+# Build the Rust formatter (debug)
+pnpm build:rust
 
 # Build release version (optimized)
-cargo build --release
+pnpm build:rust:release
 
-# Build just the napi module
+# Or manually:
 cargo build -p mdx-formatter-napi
+cp target/debug/libmdx_formatter_napi.so crates/mdx-formatter-napi/mdx-formatter-napi.node
 ```
 
 ## Testing
 
 ```bash
-# Run Rust unit tests
+# Run Rust unit tests (315 tests)
 cargo test
 
 # Run JS tests against Rust formatter (requires build first)
-pnpm test:rust
+pnpm test:rust              # 29 Rust-specific tests
+pnpm test:rust-passthrough  # 85 tests — full TS behavior comparison
 ```
 
-## Current Status
+## Implemented Formatting Rules
 
-This is a proof of concept. Current capabilities:
+All formatting rules from the TypeScript version are implemented:
 
-### Working
-
-- [x] Markdown parsing via markdown-rs (CommonMark + GFM + MDX + frontmatter)
-- [x] Spacing rule (empty lines between root-level elements; nested elements not yet handled)
+- [x] Spacing rule (empty lines after headings/JSX at all AST depths)
+- [x] Block-level spacing (paragraph ↔ heading, list, code block transitions)
 - [x] List indentation normalization
-- [x] Convergence loop
-- [x] napi-rs bindings (format function — scaffold only, needs @napi-rs/cli to build .node)
+- [x] JSX multi-line formatting (attribute indentation, standalone `/>` fix)
+- [x] Block JSX empty lines (opening/closing tag spacing for configured components)
+- [x] JSX content indentation (for configured container components)
+- [x] YAML frontmatter formatting (parse, reformat, unsafe value quoting)
+- [x] HTML block formatting (minimal indentation formatter replacing Prettier)
+- [x] Full settings deserialization (all 10 fields via serde with camelCase JSON)
+- [x] Convergence loop and empty line normalization
 
-### Not Yet Implemented
+### Plugin Validation
 
-- [ ] YAML frontmatter formatting
-- [ ] JSX multi-line formatting
-- [ ] HTML block formatting (Prettier equivalent)
-- [ ] Japanese text handling
-- [ ] Block JSX empty lines
-- [ ] Admonition preservation
-- [ ] Config file loading
-- [ ] CLI binary
+9 of 10 TypeScript plugins are NOT needed in Rust because the hybrid approach preserves original text (no AST round-tripping):
 
-## Known Limitations (POC)
+- preserve-jsx, preserve-image-alt, fix-autolink-output, preprocess-japanese, japanese-text, fix-formatting-issues, docusaurus-admonitions, normalize-lists, html-definition-list
 
-- **Spacing only at root level**: `collect_spacing_operations` only handles direct children of Root, unlike the TS implementation's `unist-util-visit` which recurses into all depths (blockquotes, JSX containers, etc.)
-- **Partial settings deserialization**: `from_partial_json` only handles 5 of 10 settings fields; the rest are silently ignored. Should migrate to serde derive with `#[serde(default)]`
-- **No content in dedup key**: Two different `InsertLine` operations targeting the same line would collide. The TS implementation doesn't have this issue because it uses more specific keys
-- **Unused description fields**: Each settings struct carries a `description: String` that's never consumed at runtime — inherited from the TS structure but adds unnecessary heap allocation in Rust
+The remaining plugin (fix-paragraph-spacing) is covered by the block-level spacing post-processor.
+
+## Not Yet Implemented (Infrastructure)
+
+- [ ] Config file loading (`.mdx-formatter.json`, `package.json` key)
+- [ ] CLI binary (standalone Rust CLI)
+- [ ] napi-rs CI build pipeline (cross-platform binaries)
+- [ ] Browser/WASM support
 
 ## npm Distribution Plan
 

--- a/doc/src/content/docs/architecture/rust-crate.mdx
+++ b/doc/src/content/docs/architecture/rust-crate.mdx
@@ -80,7 +80,7 @@ let settings = FormatterSettings::from_partial_json(&json);
 
 JSON field names use camelCase (matching the TypeScript/config file convention), while Rust struct fields use snake_case.
 
-**Note:** `from_partial_json` currently supports 5 of the 10 settings fields: `addEmptyLineBetweenElements`, `formatMultiLineJsx`, `addEmptyLinesInBlockJsx`, `formatYamlFrontmatter`, and `preserveAdmonitions`. The remaining fields (`expandSingleLineJsx`, `indentJsxContent`, `formatHtmlBlocksInMdx`, `errorHandling`, `autoDetectIndent`) are not yet parsed from JSON and will use their default values.
+All 10 settings fields are supported via serde deserialization with camelCase JSON keys.
 
 ## Public Exports
 
@@ -91,9 +91,10 @@ The crate re-exports through `lib.rs`:
 | `format` | `formatter` | The main formatting function |
 | `FormatterSettings` | `types` | Settings struct (re-exported at crate root) |
 | `FormatterOperation` | `types` | Operation enum (for advanced use) |
+| `format_html_block` | `html_formatter` | HTML block indentation formatter |
 
-Both `format` and `FormatterSettings` are re-exported at the crate root, so `use mdx_formatter_core::{format, FormatterSettings}` works directly. The `parser` and `types` modules are also public for consumers who need lower-level access to the AST parsing or operation types.
+Both `format` and `FormatterSettings` are re-exported at the crate root, so `use mdx_formatter_core::{format, FormatterSettings}` works directly. The `parser`, `types`, and `html_formatter` modules are also public for consumers who need lower-level access.
 
-## Current Status
+## Status
 
-The Rust crate implements a subset of the full formatter -- see [Rust Rewrite](/docs/architecture/rust-rewrite#current-status) for the detailed status of which rules are working and which are not yet implemented.
+The Rust crate implements all formatting rules from the TypeScript version. See [Rust Rewrite](/docs/architecture/rust-rewrite) for the full status and remaining infrastructure work.

--- a/doc/src/content/docs/architecture/rust-rewrite.mdx
+++ b/doc/src/content/docs/architecture/rust-rewrite.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Rust Rewrite
 
-mdx-formatter has an experimental Rust rewrite that reimplements the core formatting engine for better performance and distribution flexibility. The Rust version uses the same hybrid approach (AST analysis + line operations) as the TypeScript implementation.
+mdx-formatter has a Rust implementation that reimplements the full formatting engine for better performance and distribution flexibility. The Rust version uses the same hybrid approach (AST analysis + line operations) as the TypeScript implementation and passes all TS formatting tests.
 
 ## Why Rust?
 
@@ -37,30 +37,6 @@ The Rust implementation uses [markdown-rs](https://github.com/wooorm/markdown-rs
 - MDX, GFM, and frontmatter extensions are all supported
 - The AST structure is close enough to the TypeScript version that formatting rules can be ported directly
 
-The parser configuration in `crates/mdx-formatter-core/src/parser.rs` enables the same constructs as the TypeScript parser:
-
-```rust
-let parse_options = ParseOptions {
-    constructs: Constructs {
-        frontmatter: true,
-        gfm_table: true,
-        gfm_task_list_item: true,
-        gfm_strikethrough: true,
-        gfm_autolink_literal: true,
-        mdx_jsx_flow: true,
-        mdx_jsx_text: true,
-        mdx_esm: true,
-        mdx_expression_flow: true,
-        mdx_expression_text: true,
-        // Disable HTML when MDX is enabled (MDX JSX replaces HTML)
-        html_flow: false,
-        html_text: false,
-        ..Constructs::default()
-    },
-    ..ParseOptions::default()
-};
-```
-
 When MDX parsing fails, the parser falls back to basic markdown parsing with GFM extensions, and finally to plain CommonMark — ensuring the formatter never crashes on malformed input.
 
 ### napi-rs for Node.js Bindings
@@ -82,6 +58,68 @@ pub fn format(content: String, settings_json: Option<String>) -> napi::Result<St
 
 Settings are passed as a JSON string and deserialized on the Rust side, keeping the JavaScript/Rust boundary simple.
 
+## Crate Structure
+
+```
+crates/
+├── mdx-formatter-core/          ← Core Rust library
+│   ├── src/
+│   │   ├── lib.rs               ← Public exports
+│   │   ├── formatter.rs         ← Hybrid formatter (convergence loop + all rules)
+│   │   ├── html_formatter.rs    ← HTML block indentation formatter
+│   │   ├── parser.rs            ← markdown-rs integration (mdast parsing)
+│   │   └── types.rs             ← Settings, operations, type definitions
+│   └── tests/
+│       ├── cross_platform.rs    ← 165 cross-platform validation tests
+│       ├── plugin_validation.rs ← 42 plugin validation tests
+│       ├── spacing_recursion.rs ← 11 spacing recursion tests
+│       └── html_formatting.rs   ← HTML block formatting tests
+│
+└── mdx-formatter-napi/          ← napi-rs Node.js bindings
+    ├── src/
+    │   └── lib.rs               ← format() function exposed to JavaScript
+    └── build.rs                 ← napi-rs build configuration
+```
+
+The core library (`mdx-formatter-core`) has no Node.js dependency and can be used from any Rust project. The napi bridge (`mdx-formatter-napi`) is a thin wrapper that adds the JavaScript interface.
+
+## Implemented Formatting Rules
+
+All formatting rules from the TypeScript version are implemented in Rust:
+
+| Rule | Status | Notes |
+| --- | --- | --- |
+| Heading/JSX spacing | Done | Works at all AST depths (blockquotes, JSX containers) |
+| Block-level spacing | Done | Paragraph ↔ heading, list, code block transitions |
+| List indentation | Done | Normalizes nesting to 2-space indent |
+| JSX multi-line formatting | Done | Attribute indentation, standalone `/>` fix |
+| Block JSX empty lines | Done | Opening/closing tag spacing for configured components |
+| JSX content indentation | Done | For configured container components |
+| YAML frontmatter formatting | Done | Parse, reformat, unsafe value quoting |
+| HTML block formatting | Done | Minimal indentation formatter (replaces Prettier) |
+| Settings deserialization | Done | All 10 fields via serde with camelCase JSON |
+
+### Plugin Validation
+
+9 of 10 TypeScript plugins are **not needed** in Rust. The hybrid approach preserves original text (no AST round-tripping), eliminating the bugs that the TS plugins work around:
+
+- `preserve-jsx` — JSX never mangled
+- `preserve-image-alt` — Colons in alt text preserved
+- `fix-autolink-output` — No angle brackets added to URLs
+- `preprocess-japanese` / `japanese-text` — No backslash insertion or punctuation escaping
+- `fix-formatting-issues` — No bold spacing or entity issues
+- `docusaurus-admonitions` — `:::` syntax preserved as-is
+- `normalize-lists` / `html-definition-list` — Content preserved as-is
+
+## Test Coverage
+
+| Suite | Count | Description |
+| --- | --- | --- |
+| Rust cargo tests | 315 | Unit + cross-platform + plugin validation + spacing + HTML |
+| TS passthrough | 85/85 | Rust matches TS behavior for all formatting |
+| Rust-specific TS | 29/29 | Tests via napi bridge |
+| Existing TS tests | 207/207 | No regressions |
+
 ## npm Distribution Plan
 
 For production distribution, napi-rs publishes platform-specific binaries as optional npm dependencies:
@@ -96,56 +134,11 @@ For production distribution, napi-rs publishes platform-specific binaries as opt
 
 When a user runs `npm install @takazudo/mdx-formatter`, npm's optional dependency resolution automatically downloads only the binary matching their platform. This is the same approach used by SWC, Biome, and Lightning CSS.
 
-## Crate Structure
+## Remaining Work
 
-```
-crates/
-├── mdx-formatter-core/          ← Core Rust library
-│   ├── src/
-│   │   ├── lib.rs               ← Public exports
-│   │   ├── formatter.rs         ← Hybrid formatter (convergence loop + rules)
-│   │   ├── parser.rs            ← markdown-rs integration (mdast parsing)
-│   │   └── types.rs             ← Settings, operations, type definitions
-│   └── tests/
-│       └── cross_platform.rs    ← 144 cross-platform validation tests
-│
-└── mdx-formatter-napi/          ← napi-rs Node.js bindings
-    ├── src/
-    │   └── lib.rs               ← format() function exposed to JavaScript
-    └── build.rs                 ← napi-rs build configuration
-```
+The formatting engine is complete. Remaining tasks are infrastructure:
 
-The core library (`mdx-formatter-core`) has no Node.js dependency and can be used from any Rust project. The napi bridge (`mdx-formatter-napi`) is a thin wrapper that adds the JavaScript interface.
-
-## Current Status
-
-### Working
-
-- Markdown parsing via markdown-rs (CommonMark + GFM + MDX + frontmatter)
-- Spacing rule (empty lines between elements at root level)
-- List indentation normalization
-- Convergence loop (max 3 iterations)
-- Empty line normalization (collapse 3+ consecutive newlines)
-- napi-rs bindings (scaffold with format function)
-- Settings deserialization from partial JSON
-- 162 Rust tests passing (18 unit + 144 cross-platform)
-
-### Not Yet Implemented
-
-- YAML frontmatter formatting
-- JSX multi-line formatting
-- HTML block formatting (Prettier equivalent)
-- Japanese text handling
-- Block JSX empty lines
-- Admonition preservation
-- Config file loading
-- CLI binary
-
-## Known Limitations
-
-The Rust POC has several known limitations documented for future work:
-
-- **Spacing only at root level**: The `collect_spacing_operations` function only processes direct children of the Root node. The TypeScript version uses `unist-util-visit` to recurse into all depths (blockquotes, JSX containers, etc.)
-- **Partial settings deserialization**: `from_partial_json` manually handles 5 of 10 settings fields. The remaining fields are silently ignored. This should be migrated to serde derive with `#[serde(default)]`
-- **No content in dedup key**: Two different `InsertLine` operations targeting the same line would collide in the dedup set. The TypeScript version avoids this because it uses more specific keys
-- **Unused description fields**: Each settings struct carries a `description: String` field inherited from the TypeScript structure that adds unnecessary heap allocation in Rust
+- Config file loading (`.mdx-formatter.json`, `package.json` key)
+- CLI binary (standalone Rust CLI)
+- napi-rs CI build pipeline (cross-platform binary generation)
+- Browser/WASM support

--- a/doc/src/content/docs/architecture/testing-strategy.mdx
+++ b/doc/src/content/docs/architecture/testing-strategy.mdx
@@ -5,11 +5,11 @@ sidebar_position: 3
 
 # Testing Strategy
 
-mdx-formatter uses a multi-layered testing approach. The TypeScript test suite defines the formatting contract, while the Rust cross-platform tests validate that the Rust implementation produces compatible output.
+mdx-formatter uses a multi-layered testing approach. The TypeScript test suite defines the formatting contract, the Rust tests validate the Rust implementation, and the passthrough tests verify that both implementations produce identical output.
 
 ## TypeScript Test Suite
 
-The TypeScript tests in `test/` are the source of truth for what correctly formatted output looks like. They cover all 10 formatting rules across various input scenarios.
+The TypeScript tests in `test/` are the source of truth for what correctly formatted output looks like. They cover all formatting rules across various input scenarios.
 
 ### Test Files
 
@@ -18,133 +18,94 @@ The TypeScript tests in `test/` are the source of truth for what correctly forma
 | `formatter.test.ts` | Core formatting | Heading spacing, list indentation, JSX handling, Japanese text |
 | `mdx-formatter.test.ts` | MdxFormatter internals | AST analysis + line operations, conflict resolution |
 | `idempotency.test.ts` | Stability | `format(format(x)) === format(x)` for all inputs |
-| `html-blocks.test.ts` | HTML formatting | Prettier-based HTML block formatting in MDX |
+| `html-blocks.test.ts` | HTML formatting | HTML block indentation in MDX |
 | `load-config.test.ts` | Configuration | `.mdx-formatter.json` loading and merging |
 | `url-autolink.test.ts` | URL handling | Autolink behavior and URL preservation |
 
 All tests use vitest and can be run with:
 
 ```bash
-pnpm test           # Run all tests once
+pnpm test           # Run all 207 tests once
 pnpm test:watch     # Watch mode
 pnpm test:coverage  # Coverage report
 ```
 
-## Idempotency Testing
+## Rust Test Suite
 
-A core property of the formatter is idempotency: formatting an already-formatted file must produce identical output. The `idempotency.test.ts` suite verifies this across many document shapes:
+The Rust tests in `crates/mdx-formatter-core/` validate the Rust formatting engine independently. There are 315 tests across multiple test files.
 
-```typescript
-// Every test follows this pattern:
-const first = await format(input);
-const second = await format(first);
-assert.strictEqual(first, second);
-```
+### Test Files
 
-Test cases include:
-
-- Simple content (single paragraph)
-- Complex documents (frontmatter + headings + lists + code blocks + JSX)
-- Documents that need fixes (heading spacing, list indent)
-- Edge cases (empty input, whitespace-only, single newline)
-
-The convergence loop (max 3 iterations) in the formatter guarantees this property. If `format_once(x) !== x`, the formatter applies another pass. After 3 passes, the output is returned regardless.
-
-## Rust Cross-Platform Tests
-
-The file `crates/mdx-formatter-core/tests/cross_platform.rs` contains 144 tests ported from the TypeScript suite. These tests validate that the Rust formatter produces the same output as the TypeScript version for the subset of rules currently implemented.
-
-### Test Organization
-
-The cross-platform tests are organized into numbered sections:
-
-| Section | Category | Count |
+| File | Count | Focus |
 | --- | --- | --- |
-| 1 | Basic Markdown Formatting | 14 |
-| 2 | List Indentation | 9 |
-| 3 | Idempotency | 9 |
-| 4 | MDX/JSX Preservation | 11 |
-| 5a | Parsing — CommonMark | 21 |
-| 5b | Parsing — GFM | 4 |
-| 5c | Parsing — MDX | 6 |
-| 5d | Parsing — Frontmatter | 4 |
-| 6 | Japanese Text | 11 |
-| 7 | Content Preservation | 12 |
-| 8 | JSX Spacing Rules | 4 |
-| 9 | Heading/Content Interaction | 2 |
-| 10 | Code Block Interaction | 4 |
-| 11 | Blockquote | 3 |
-| 12 | Error Handling/Edge Cases | 4 |
-| 13 | Regression Tests | 4 |
-| 14 | Complex Documents | 3 |
-| 15 | TODO (unimplemented rules) | 7 |
-| 16 | Settings Configuration | 5 |
-| 17 | Convergence Loop | 3 |
-| 18 | Stress Tests | 4 |
-
-### Test Annotations
-
-Tests use annotations to document the Rust formatter's current capabilities:
-
-- **No annotation**: Test passes and validates identical behavior to TypeScript
-- **`PARTIAL:`**: Rust formatter only partially handles the case (missing rule implementation). The test documents the current Rust behavior rather than the expected final behavior
-- **`TODO:`**: Test will pass once the corresponding rule is implemented. Currently verifies the formatter doesn't crash and preserves content
-
-Example of a `TODO` test:
-
-```rust
-#[test]
-fn todo_jsx_empty_lines_in_block_component() {
-    // TODO: Once addEmptyLinesInBlockJsx is implemented, expected should be:
-    // "<InfoBox>\n\nContent\n\n</InfoBox>"
-    let settings = settings_with_block_components();
-    let input = "<InfoBox>\nContent\n</InfoBox>";
-    let result = format(input, &settings);
-    assert!(result.contains("InfoBox"), "Component name preserved");
-    assert!(result.contains("Content"), "Content preserved");
-}
-```
-
-### Running Rust Tests
+| `src/formatter.rs` (inline) | 97 | Unit tests for all formatting rules, YAML, settings |
+| `tests/cross_platform.rs` | 165 | Cross-platform validation ported from TS suite |
+| `tests/plugin_validation.rs` | 42 | Validates that 9/10 TS plugins are not needed in Rust |
+| `tests/spacing_recursion.rs` | 11 | Spacing at all AST depths (blockquotes, JSX) |
 
 ```bash
-# Run all Rust tests (unit + cross-platform)
-cargo test
-
-# Run only cross-platform tests
-cargo test --test cross_platform
-
-# Run with output for debugging
-cargo test -- --nocapture
+cargo test               # Run all 315 Rust tests
+cargo test --test cross_platform  # Just cross-platform tests
 ```
+
+## Passthrough Tests (Rust ↔ TypeScript Comparison)
+
+The passthrough test suite runs TypeScript test cases against the Rust formatter via the napi bridge, verifying identical output.
+
+| Suite | Count | Description |
+| --- | --- | --- |
+| `test:rust` | 29 | Rust-specific tests (basic formatting, lists, JSX, Japanese) |
+| `test:rust-passthrough` | 85 | Full TS behavior comparison (all formatting rules) |
+
+```bash
+pnpm build:rust              # Build the napi module
+pnpm test:rust               # 29 Rust-specific TS tests
+pnpm test:rust-passthrough   # 85 passthrough tests
+```
+
+The passthrough tests use `describe.skipIf(!isRustFormatterAvailable())` so they skip gracefully when the napi module is not built.
 
 ## How the Test Bridge Works
 
-The napi-rs bridge enables running the TypeScript test suite against the Rust formatter. The flow is:
+The napi-rs bridge enables running the TypeScript test suite against the Rust formatter:
 
 ```
 vitest
   ↓
-src/rust-formatter.ts    ← JS wrapper
+src/rust-formatter.ts    ← JS wrapper (loads .node binary)
   ↓
-napi-rs binding          ← loads platform .node binary
+napi-rs binding          ← platform-specific native module
   ↓
 mdx-formatter-core       ← Rust formatting engine
   ↓
-formatted output         ← returned to vitest
+formatted output         ← returned to vitest for assertion
 ```
 
-The JS wrapper (`src/rust-formatter.ts`) loads the native module and provides the same `format()` API as the TypeScript formatter. This allows running `pnpm test:rust` to validate the Rust output against the existing test expectations.
+## Idempotency Testing
+
+A core property of the formatter is idempotency: formatting an already-formatted file must produce identical output. Both TS and Rust test suites verify this:
+
+```typescript
+const first = await format(input);
+const second = await format(first);
+expect(first).toBe(second);
+```
+
+The convergence loop (max 3 iterations) in both implementations guarantees this property.
+
+## Plugin Validation Tests
+
+The `tests/plugin_validation.rs` suite (42 tests) validates that the Rust formatter handles all cases that TypeScript plugins were created for — without needing those plugins. Each test creates input that would trigger a TS plugin and verifies the Rust formatter handles it correctly through its hybrid approach (original text preservation).
 
 ## Testing New Rules
 
-When adding a new formatting rule, follow this process:
+When adding a new formatting rule:
 
 1. Write TypeScript tests first in `test/` — these define the contract
 2. Implement the rule in `src/mdx-formatter.ts`
 3. Verify TypeScript tests pass: `pnpm test`
-4. Port relevant test cases to `crates/mdx-formatter-core/tests/cross_platform.rs`
-5. Implement the rule in `crates/mdx-formatter-core/src/formatter.rs`
+4. Port test cases to Rust (`tests/cross_platform.rs` or a new test file)
+5. Implement the rule in Rust (`src/formatter.rs` or a new module)
 6. Verify Rust tests pass: `cargo test`
-
-The TypeScript tests are always the source of truth. Rust tests should produce identical output for the same inputs.
+7. Add passthrough tests in `test/rust-passthrough.test.ts`
+8. Verify passthrough: `pnpm build:rust && pnpm test:rust-passthrough`


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/mdx-formatter/issues/29

---

## Summary
- Update all Rust migration documentation to reflect current status: all formatting rules implemented, 315 Rust tests, 85/85 passthrough
- Remove stale "Not Yet Implemented" sections and "Known Limitations" that are resolved
- Add full rule implementation table, plugin validation results, updated test counts

## Changes
- `RUST_REWRITE.md` — Complete rewrite: remove POC limitations, document all implemented rules, update build commands
- `doc/architecture/rust-rewrite.mdx` — Full rule status table, plugin validation section, test coverage table, remaining work section
- `doc/architecture/testing-strategy.mdx` — Add passthrough tests documentation, update Rust test counts to 315, remove TODO test examples
- `doc/architecture/rust-crate.mdx` — Note all 10 settings fields supported, add html_formatter export

## Test Plan
- Doc site builds successfully (56 pages)
- CI green