### PR TITLE
Fix doc deploy: build main package before doc site

### DIFF
--- a/.github/actions/build-astro/action.yml
+++ b/.github/actions/build-astro/action.yml
@@ -33,6 +33,10 @@ runs:
       run: pnpm install --frozen-lockfile
       shell: bash
 
+    - name: Build main package
+      run: pnpm build
+      shell: bash
+
     - name: Build Astro site
       run: pnpm build
       shell: bash


### PR DESCRIPTION
## Summary
- The playground page imports `@takazudo/mdx-formatter/browser` which resolves to `dist/browser.js`
- The deploy workflow only built the doc site, not the main TypeScript package
- Added a `pnpm build` step before the doc site build in the build-astro action

Fixes the Production Deploy failure after PR #37 merge.