### PR TITLE
Add WASM build step to doc site CI deploy

### DIFF
--- a/.github/actions/build-astro/action.yml
+++ b/.github/actions/build-astro/action.yml
@@ -29,8 +29,19 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
 
+    - name: Setup Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      shell: bash
+
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+      shell: bash
+
+    - name: Build WASM for playground
+      run: pnpm build:wasm:doc
       shell: bash
 
     - name: Build main package


### PR DESCRIPTION
## Summary
- Add Rust toolchain, wasm-pack, and `pnpm build:wasm:doc` to the `build-astro` composite action
- The doc site playground loads WASM at runtime but the files were gitignored and never built during CI deploy

## Changes
- `.github/actions/build-astro/action.yml`: Add 3 new steps before `Build main package`:
  1. `dtolnay/rust-toolchain@stable` — install Rust
  2. `curl | sh` — install wasm-pack
  3. `pnpm build:wasm:doc` — build WASM and copy to doc/public/wasm/

## Test Plan
- CI green on all 3 Node versions
- Deploy workflow will now produce WASM files for the playground