### PR TITLE
Fix playground WASM module loading failure

### DIFF
--- a/doc/src/components/formatter-playground.tsx
+++ b/doc/src/components/formatter-playground.tsx
@@ -67,11 +67,10 @@ let wasmPromise: Promise<WasmModule> | null = null;
 function loadWasm(): Promise<WasmModule> {
   if (wasmPromise) return wasmPromise;
   wasmPromise = (async () => {
-    // Dynamic import with variable path to prevent Rollup from resolving
-    // at build time — the wasm-pkg dir is a build artifact from wasm-pack
-    // that may not exist in CI environments without Rust toolchain.
-    const wasmPath = '../wasm-pkg/mdx_formatter_wasm';
-    const mod = await import(/* @vite-ignore */ wasmPath);
+    // Import from public/wasm/ which is populated by build:wasm:doc.
+    // Uses BASE_URL for correct path resolution on the deployed site.
+    const wasmJsUrl = `${import.meta.env.BASE_URL}wasm/mdx_formatter_wasm.js`;
+    const mod = await import(/* @vite-ignore */ wasmJsUrl);
     await mod.default(
       `${import.meta.env.BASE_URL}wasm/mdx_formatter_wasm_bg.wasm`,
     );

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "benchmark": "npx tsx benchmark/run.ts",
     "build:wasm": ". \"$HOME/.cargo/env\" && wasm-pack build crates/mdx-formatter-wasm --target web --out-dir ../../wasm/pkg",
     "build:wasm:bundler": ". \"$HOME/.cargo/env\" && wasm-pack build crates/mdx-formatter-wasm --target bundler --out-dir ../../wasm/pkg-bundler",
-    "build:wasm:doc": ". \"$HOME/.cargo/env\" && wasm-pack build crates/mdx-formatter-wasm --target web --out-dir ../../doc/src/wasm-pkg && mkdir -p doc/public/wasm && cp doc/src/wasm-pkg/mdx_formatter_wasm_bg.wasm doc/public/wasm/",
+    "build:wasm:doc": ". \"$HOME/.cargo/env\" && wasm-pack build crates/mdx-formatter-wasm --target web --out-dir ../../doc/src/wasm-pkg && mkdir -p doc/public/wasm && cp doc/src/wasm-pkg/mdx_formatter_wasm_bg.wasm doc/public/wasm/ && cp doc/src/wasm-pkg/mdx_formatter_wasm.js doc/public/wasm/",
     "b4push": "./scripts/run-b4push.sh",
     "doc:start": "pnpm --dir doc start",
     "prepublishOnly": "tsc && vitest run"


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/mdx-formatter/issues/64

---

## Summary
- Fix playground failing to load WASM module due to missing JS wrapper in the served static assets
- The `build:wasm:doc` script now copies both the `.wasm` binary and the JS glue file to `doc/public/wasm/`

## Changes
- **`package.json`**: Updated `build:wasm:doc` to also copy `mdx_formatter_wasm.js` to `doc/public/wasm/`
- **`doc/src/components/formatter-playground.tsx`**: Changed the dynamic WASM import to use an absolute `import.meta.env.BASE_URL`-based path (`wasm/mdx_formatter_wasm.js`) instead of a relative path (`../wasm-pkg/mdx_formatter_wasm`) that resolved to a non-existent URL at runtime

## Test Plan
- Deploy the doc site and verify the playground at `/docs/playground` loads the WASM module and formats input correctly
- CI builds the WASM and Astro site end-to-end via `build:wasm:doc` + `pnpm --dir doc build`