### PR TITLE
Add tighten-list-item-spacing list-normalize rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Dated release entries mirror the per-version pages under
 
 ### Added — List Normalize rule bundle (epic #80)
 
-Four new rules that clean up AI-authored list-item content. Exposed as flat
+Five rules that clean up AI-authored list-item content. Exposed as flat
 top-level kebab-case keys in the public config (not nested under a parent
 object) so each rule can be opted in/out independently:
 
@@ -19,6 +19,11 @@ object) so each rule can be opted in/out independently:
   of a list item when heuristics show the second is a continuation of the
   first sentence (lowercase / backtick / opening-punctuation start).
   (sub-issue #82)
+- **`tighten-list-item-spacing`** (`"off"` / `"heuristic"` (default) /
+  `"aggressive"`) — Collapse a single blank line between adjacent sibling
+  list items. `"heuristic"` fires only when every item in the list is
+  `ParagraphsOnly`; `"aggressive"` drops that shape gate. Double-blank
+  separators are preserved. (issue #90)
 - **`recover-escaped-code-in-lists`** (`"off"` / `"safe"` (default) /
   `"aggressive"`) — Re-indent a fenced code block that escaped to column 0
   between two list items so CommonMark parses it as a child of the
@@ -31,9 +36,9 @@ object) so each rule can be opted in/out independently:
 - **`recover-escaped-paragraphs-in-lists`** (`"off"` (default) /
   `"heuristic"` / `"aggressive"`) — Re-indent a paragraph that escaped to
   column 0 between two list items. Defaults to off because the heuristic
-  has the highest false-positive risk of the four rules. (sub-issue #85)
+  has the highest false-positive risk of the five rules. (sub-issue #85)
 
-All four rules apply recursively to nested sublists (sub-issue #86) and
+All five rules apply recursively to nested sublists (sub-issue #86) and
 share a common detection pass with oscillation guarding (sub-issue #81).
 
 ### Added — `--dry-run` CLI + `dryRunReport()` API (sub-issue #87)
@@ -51,12 +56,12 @@ share a common detection pass with oscillation guarding (sub-issue #81).
 
 ### Added — Regression safety net (sub-issue #88)
 
-- `test/fixtures/` — real-content input fixtures for each of the four
+- `test/fixtures/` — real-content input fixtures for each of the five
   rules, paired with an `.expected.md` baseline consumed by the
   integration tests in `test/formatter.test.ts`.
 - `test/fixtures/baseline-loose-list-preserved.md` — the "formatter is
   innocent" assertion: loose-shape snippet from `local-llm-search-spike.mdx`
-  round-trips byte-identically when all four list-normalize rules are
+  round-trips byte-identically when all five list-normalize rules are
   `"off"`. Documents the pre-rule finding from the epic investigation.
 - `test/snapshots/` — per-fixture default-settings output baselines.
   `test/snapshots.test.ts` re-runs the formatter and asserts
@@ -68,7 +73,7 @@ share a common detection pass with oscillation guarding (sub-issue #81).
 
 `crates/mdx-formatter-napi` and `crates/mdx-formatter-wasm` called
 `FormatterSettings::from_partial_json` directly, which silently dropped
-the four list-normalize top-level kebab-case keys because
+the five list-normalize top-level kebab-case keys because
 `FormatterSettings::list_normalize` is `#[serde(skip)]`. They now route
 through a new `from_public_json()` helper in core that lifts those keys
 into `settings.list_normalize` before deserializing the rest. Discovered

--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ console.log(formatted); // '# Hello\n\nWorld'
 
 ### List Normalize
 
-Four rules clean up AI-authored list-item content. They are exposed as flat
+Five rules clean up AI-authored list-item content. They are exposed as flat
 top-level kebab-case keys (not nested objects):
 
 | Key                                   | Default       | Purpose                                                                           |
 | ------------------------------------- | ------------- | --------------------------------------------------------------------------------- |
 | `tighten-list-continuations`          | `"heuristic"` | Collapse blank gaps inside list items whose children are continuation paragraphs. |
+| `tighten-list-item-spacing`           | `"heuristic"` | Collapse single blank gaps between adjacent sibling list items when safe.         |
 | `recover-escaped-code-in-lists`       | `"safe"`      | Re-indent fenced code blocks that escaped to column 0 between list items.         |
 | `recover-escaped-tables-in-lists`     | `"safe"`      | Re-indent GFM tables that escaped to column 0 between list items.                 |
 | `recover-escaped-paragraphs-in-lists` | `"off"`       | Re-indent continuation paragraphs that escaped to column 0 (opt-in).              |

--- a/crates/mdx-formatter-cli/tests/dry_run.rs
+++ b/crates/mdx-formatter-cli/tests/dry_run.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `--dry-run` CLI flag.
 //!
 //! Covers the three acceptance-criterion scenarios from issue #87:
-//!   (a) a file containing all four list-normalize pattern classes
+//!   (a) a file containing all five list-normalize pattern classes
 //!       produces a non-empty report, exits 0, and leaves the file
 //!       byte-identical on disk;
 //!   (b) a file with no normalizations produces an empty report and
@@ -51,8 +51,8 @@ fn write_file(path: &Path, content: &str) {
 }
 
 /// Fixture: has a recover-escaped-code case (#83) AND a tighten (#82)
-/// continuation — enough to exercise two of the four list-normalize rules
-/// through the same report. We don't try to exercise all four in one file
+/// continuation — enough to exercise two of the five list-normalize rules
+/// through the same report. We don't try to exercise all five in one file
 /// because their triggers interact (see rule ordering docs in core). Two is
 /// sufficient to prove the sink/flag machinery works end-to-end.
 const FIXTURE_WITH_CHANGES: &str = "1. first item with a long first sentence.

--- a/crates/mdx-formatter-core/src/config.rs
+++ b/crates/mdx-formatter-core/src/config.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use crate::types::{
     FormatterSettings, ListNormalizeSettings, RecoverEscapedCodeMode,
     RecoverEscapedParagraphsMode, RecoverEscapedTablesMode, TightenListContinuationsMode,
+    TightenListItemSpacingMode,
 };
 
 /// Result of loading full config — settings plus CLI-level exclude patterns.
@@ -29,12 +30,13 @@ pub struct FullConfig {
 /// lifts them into `FormatterSettings::list_normalize` after the 3-layer merge.
 const LIST_NORMALIZE_TOP_KEYS: &[&str] = &[
     "tighten-list-continuations",
+    "tighten-list-item-spacing",
     "recover-escaped-code-in-lists",
     "recover-escaped-tables-in-lists",
     "recover-escaped-paragraphs-in-lists",
 ];
 
-/// Extract the 4 list-normalize top-level keys from a merged JSON object into
+/// Extract the 5 list-normalize top-level keys from a merged JSON object into
 /// a `ListNormalizeSettings`, falling back to per-field defaults. Missing keys
 /// keep defaults; unknown variants also fall back to defaults (permissive parse).
 pub(crate) fn extract_list_normalize(merged: &Value) -> ListNormalizeSettings {
@@ -47,6 +49,11 @@ pub(crate) fn extract_list_normalize(merged: &Value) -> ListNormalizeSettings {
     if let Some(v) = obj.get("tighten-list-continuations") {
         if let Ok(mode) = serde_json::from_value::<TightenListContinuationsMode>(v.clone()) {
             settings.tighten_list_continuations = mode;
+        }
+    }
+    if let Some(v) = obj.get("tighten-list-item-spacing") {
+        if let Ok(mode) = serde_json::from_value::<TightenListItemSpacingMode>(v.clone()) {
+            settings.tighten_list_item_spacing = mode;
         }
     }
     if let Some(v) = obj.get("recover-escaped-code-in-lists") {
@@ -184,7 +191,7 @@ pub fn load_full_config_from(
     // rest to FormatterSettings serde deserialization (which uses camelCase).
     let list_normalize = extract_list_normalize(&final_json);
 
-    // Strip the 4 keys so they do not trip the serde deserializer if it ever
+    // Strip the 5 keys so they do not trip the serde deserializer if it ever
     // moves to deny_unknown_fields. Also keeps the JSON round-trip clean.
     let mut settings_json = final_json.clone();
     if let Value::Object(ref mut map) = settings_json {
@@ -208,12 +215,12 @@ pub fn load_config(config_path: Option<&str>, programmatic: Option<&Value>) -> F
 }
 
 /// Build a `FormatterSettings` from a single already-merged JSON value that
-/// may include the four public `list-normalize` top-level kebab-case keys.
+/// may include the five public `list-normalize` top-level kebab-case keys.
 ///
 /// Call this from front-ends (napi, wasm, …) that accept a single blob of
 /// public settings JSON already produced by their own loader (e.g. the TS
 /// `loadConfig`). It:
-///   1. extracts the four list-normalize kebab-case keys into
+///   1. extracts the five list-normalize kebab-case keys into
 ///      `ListNormalizeSettings` via `extract_list_normalize`, then
 ///   2. strips those keys from a clone of the JSON before handing the rest
 ///      to `FormatterSettings::from_partial_json` (camelCase serde path), and
@@ -605,10 +612,15 @@ mod tests {
     fn load_config_list_normalize_defaults() {
         let dir = tempfile::tempdir().unwrap();
         let settings = load_full_config_from(dir.path(), None, None).settings;
-        // Defaults: tighten=heuristic, recover-code=safe, recover-tables=safe, recover-paragraphs=off
+        // Defaults: both tighten rules=heuristic, recover-code/tables=safe,
+        // recover-paragraphs=off
         assert_eq!(
             settings.list_normalize.tighten_list_continuations,
             TightenListContinuationsMode::Heuristic
+        );
+        assert_eq!(
+            settings.list_normalize.tighten_list_item_spacing,
+            TightenListItemSpacingMode::Heuristic
         );
         assert_eq!(
             settings.list_normalize.recover_escaped_code_in_lists,
@@ -632,6 +644,7 @@ mod tests {
             &config_path,
             r#"{
                 "tighten-list-continuations": "aggressive",
+                "tighten-list-item-spacing": "off",
                 "recover-escaped-code-in-lists": "off",
                 "recover-escaped-tables-in-lists": "aggressive",
                 "recover-escaped-paragraphs-in-lists": "heuristic"
@@ -645,6 +658,10 @@ mod tests {
         assert_eq!(
             settings.list_normalize.tighten_list_continuations,
             TightenListContinuationsMode::Aggressive
+        );
+        assert_eq!(
+            settings.list_normalize.tighten_list_item_spacing,
+            TightenListItemSpacingMode::Off
         );
         assert_eq!(
             settings.list_normalize.recover_escaped_code_in_lists,
@@ -703,6 +720,10 @@ mod tests {
         );
         // Other keys keep defaults
         assert_eq!(
+            settings.list_normalize.tighten_list_item_spacing,
+            TightenListItemSpacingMode::Heuristic
+        );
+        assert_eq!(
             settings.list_normalize.recover_escaped_code_in_lists,
             RecoverEscapedCodeMode::Safe
         );
@@ -735,7 +756,7 @@ mod tests {
     // ── from_public_json tests (issue #88) ──
     //
     // `from_public_json` is the one-shot settings builder the napi and wasm
-    // shims call. Regression guard against the #88 bug where the four
+    // shims call. Regression guard against the #88 bug where the five
     // list-normalize kebab-case keys were silently dropped (because
     // `FormatterSettings::list_normalize` is `#[serde(skip)]`), which caused
     // the TS "formatter is innocent" baseline test to fail even with all
@@ -745,6 +766,7 @@ mod tests {
     fn from_public_json_lifts_list_normalize_kebab_keys() {
         let json: Value = serde_json::json!({
             "tighten-list-continuations": "off",
+            "tighten-list-item-spacing": "aggressive",
             "recover-escaped-code-in-lists": "off",
             "recover-escaped-tables-in-lists": "aggressive",
             "recover-escaped-paragraphs-in-lists": "heuristic",
@@ -753,6 +775,10 @@ mod tests {
         assert_eq!(
             settings.list_normalize.tighten_list_continuations,
             TightenListContinuationsMode::Off
+        );
+        assert_eq!(
+            settings.list_normalize.tighten_list_item_spacing,
+            TightenListItemSpacingMode::Aggressive
         );
         assert_eq!(
             settings.list_normalize.recover_escaped_code_in_lists,
@@ -792,6 +818,11 @@ mod tests {
         assert_eq!(
             settings.list_normalize.tighten_list_continuations,
             TightenListContinuationsMode::Heuristic,
+            "default must be heuristic"
+        );
+        assert_eq!(
+            settings.list_normalize.tighten_list_item_spacing,
+            TightenListItemSpacingMode::Heuristic,
             "default must be heuristic"
         );
         assert_eq!(

--- a/crates/mdx-formatter-core/src/formatter.rs
+++ b/crates/mdx-formatter-core/src/formatter.rs
@@ -51,10 +51,6 @@ static YAML_BLOCK_SCALAR_KEY_RE: LazyLock<Regex> =
 static SPECIAL_START_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[!&*%@`]").unwrap());
 
-// Compile once at startup, not on every format call
-static MULTIPLE_NEWLINES_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
-
 // ============================================================================
 // ReportSink — audit / dry-run mechanism
 // ============================================================================
@@ -261,8 +257,7 @@ fn format_once(content: &str, settings: &FormatterSettings, sink: &mut dyn Repor
     // ── list-normalize pipeline (issue #81: detect; #82-#85: rule bodies) ──
     // Order inside the convergence loop:
     //   detect → recover-escaped (#83/#84/#85) → tighten-continuation (#82)
-    //          → wrap-markdown (existing)
-    // Rule bodies are empty stubs here; they are filled in by #82-#85.
+    //          → tighten-item-spacing (#90) → wrap-markdown (existing)
     let list_item_shapes = collect_list_item_shapes(&ast);
     let escaped_block_candidates = collect_escaped_block_candidates(&ast, &lines);
     apply_recover_escaped_code_in_lists(
@@ -293,6 +288,14 @@ fn format_once(content: &str, settings: &FormatterSettings, sink: &mut dyn Repor
         sink,
     );
     apply_tighten_list_continuations(
+        settings,
+        &list_item_shapes,
+        &ast,
+        &lines,
+        &mut operations,
+        sink,
+    );
+    apply_tighten_list_item_spacing(
         settings,
         &list_item_shapes,
         &ast,
@@ -2642,6 +2645,147 @@ fn second_paragraph_looks_like_continuation(lines: &[&str], p_start_0: usize) ->
     )
 }
 
+/// Collapse blank lines *between* adjacent sibling list items in the same
+/// list, leaving intentional double-blank separators alone.
+fn apply_tighten_list_item_spacing(
+    settings: &FormatterSettings,
+    shapes: &[ListItemDetection],
+    ast: &Node,
+    lines: &[&str],
+    operations: &mut Vec<FormatterOperation>,
+    sink: &mut dyn ReportSink,
+) {
+    use crate::types::TightenListItemSpacingMode;
+    use std::collections::HashMap;
+
+    let mode = settings.list_normalize.tighten_list_item_spacing;
+    if matches!(mode, TightenListItemSpacingMode::Off) {
+        return;
+    }
+
+    let detection_by_span: HashMap<(usize, usize), &ListItemDetection> = shapes
+        .iter()
+        .map(|s| ((s.start_line, s.end_line), s))
+        .collect();
+
+    walk_for_tighten_list_item_spacing(
+        ast,
+        lines,
+        &detection_by_span,
+        mode,
+        operations,
+        sink,
+    );
+}
+
+fn walk_for_tighten_list_item_spacing(
+    node: &Node,
+    lines: &[&str],
+    detection_by_span: &std::collections::HashMap<(usize, usize), &ListItemDetection>,
+    mode: crate::types::TightenListItemSpacingMode,
+    operations: &mut Vec<FormatterOperation>,
+    sink: &mut dyn ReportSink,
+) {
+    use crate::types::{ListItemShape, TightenListItemSpacingMode};
+
+    if let Node::List(list) = node {
+        let items: Vec<_> = list
+            .children
+            .iter()
+            .filter_map(|child| match child {
+                Node::ListItem(item) => Some(item),
+                _ => None,
+            })
+            .collect();
+        if items.len() >= 2 {
+            let heuristic_ok = matches!(mode, TightenListItemSpacingMode::Aggressive)
+                || items.iter().all(|item| {
+                    let Some(pos) = &item.position else {
+                        return false;
+                    };
+                    let span = (
+                        pos.start.line.saturating_sub(1),
+                        pos.end.line.saturating_sub(1),
+                    );
+                    matches!(
+                        detection_by_span.get(&span).map(|d| d.shape),
+                        Some(ListItemShape::ParagraphsOnly)
+                    )
+                });
+            if heuristic_ok {
+                emit_tighten_item_spacing_ops_for_list(
+                    items.as_slice(),
+                    detection_by_span,
+                    lines,
+                    operations,
+                    sink,
+                );
+            }
+        }
+    }
+
+    for child in get_children(node) {
+        walk_for_tighten_list_item_spacing(
+            child,
+            lines,
+            detection_by_span,
+            mode,
+            operations,
+            sink,
+        );
+    }
+}
+
+fn emit_tighten_item_spacing_ops_for_list(
+    items: &[&markdown::mdast::ListItem],
+    detection_by_span: &std::collections::HashMap<(usize, usize), &ListItemDetection>,
+    lines: &[&str],
+    operations: &mut Vec<FormatterOperation>,
+    sink: &mut dyn ReportSink,
+) {
+    for window in items.windows(2) {
+        let (Some(pos1), Some(pos2)) = (&window[0].position, &window[1].position) else {
+            continue;
+        };
+        let span1 = (
+            pos1.start.line.saturating_sub(1),
+            pos1.end.line.saturating_sub(1),
+        );
+        let span2 = (
+            pos2.start.line.saturating_sub(1),
+            pos2.end.line.saturating_sub(1),
+        );
+        let (Some(det1), Some(det2)) = (detection_by_span.get(&span1), detection_by_span.get(&span2))
+        else {
+            continue;
+        };
+        let item1_end_0 = det1.last_child_line.unwrap_or(det1.end_line);
+        let item2_start_0 = det2.start_line;
+
+        // Exactly one blank line between siblings: keep double-blanks intact.
+        if item2_start_0 != item1_end_0 + 2 {
+            continue;
+        }
+        let blank_idx = item1_end_0 + 1;
+        if blank_idx >= lines.len() || !lines[blank_idx].trim().is_empty() {
+            continue;
+        }
+
+        sink.emit(ReportEntry {
+            rule: "tighten-list-item-spacing",
+            start_line: blank_idx,
+            end_line: blank_idx,
+            before: snippet_from_lines(lines, blank_idx, blank_idx),
+            after: Vec::new(),
+        });
+        operations.push(FormatterOperation::ReplaceLines {
+            start_line: blank_idx,
+            end_line: blank_idx,
+            lines: Vec::new(),
+        });
+    }
+}
+
 // ============================================================================
 // HTML Block Formatting
 // ============================================================================
@@ -3499,9 +3643,80 @@ fn leading_space_count(line: &str) -> usize {
     line.len() - line.trim_start_matches(' ').len()
 }
 
-/// Normalize consecutive empty lines to at most one empty line.
+/// Normalize consecutive empty lines to at most one empty line, except for
+/// intentional double separators between adjacent list items.
 fn normalize_empty_lines(content: &str) -> String {
-    MULTIPLE_NEWLINES_RE.replace_all(content, "\n\n").to_string()
+    let had_trailing_newline = content.ends_with('\n');
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        if !lines[i].trim().is_empty() {
+            out.push(lines[i]);
+            i += 1;
+            continue;
+        }
+
+        let start = i;
+        while i < lines.len() && lines[i].trim().is_empty() {
+            i += 1;
+        }
+        let run_len = i - start;
+        let prev_nonblank = (0..start).rev().find(|idx| !lines[*idx].trim().is_empty());
+        let next_nonblank = (i..lines.len()).find(|idx| !lines[*idx].trim().is_empty());
+
+        let blanks_to_keep = if run_len >= 2
+            && matches!(
+                (prev_nonblank, next_nonblank),
+                (Some(prev), Some(next))
+                    if preserves_list_item_double_blank(lines.as_slice(), prev, next)
+            ) {
+            2
+        } else {
+            1
+        };
+
+        out.extend(std::iter::repeat_n("", blanks_to_keep));
+    }
+
+    let mut normalized = out.join("\n");
+    if had_trailing_newline && !normalized.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
+}
+
+fn preserves_list_item_double_blank(lines: &[&str], prev_nonblank: usize, next_nonblank: usize) -> bool {
+    let Some(next_indent) = list_marker_indent(lines[next_nonblank]) else {
+        return false;
+    };
+    if let Some(prev_indent) = list_marker_indent(lines[prev_nonblank]) {
+        return prev_indent == next_indent;
+    }
+    leading_space_count(lines[prev_nonblank]) > next_indent
+}
+
+fn list_marker_indent(line: &str) -> Option<usize> {
+    let indent = leading_space_count(line);
+    let trimmed = &line[indent..];
+    let mut chars = trimmed.chars();
+    match chars.next()? {
+        '-' | '+' | '*' => chars.next().filter(|c| c.is_whitespace()).map(|_| indent),
+        c if c.is_ascii_digit() => {
+            let digits = trimmed
+                .chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .count();
+            let rest = &trimmed[digits..];
+            let mut rest_chars = rest.chars();
+            match (rest_chars.next(), rest_chars.next()) {
+                (Some('.' | ')'), Some(ws)) if ws.is_whitespace() => Some(indent),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -4208,7 +4423,6 @@ also continues the first
 1. first item
 
    also continues the first
-
 2. second item
 ";
         let settings = settings_with_recover_paragraphs_mode(
@@ -4233,7 +4447,6 @@ also continues the first
 1. first item
 
    `foo` is shorthand for the item above
-
 2. second item
 ";
         let settings = settings_with_recover_paragraphs_mode(
@@ -4294,7 +4507,6 @@ Capital start but numbering resumes so aggressive fires
 1. first item
 
    Capital start but numbering resumes so aggressive fires
-
 2. second item
 ";
         let settings = settings_with_recover_paragraphs_mode(
@@ -4319,7 +4531,6 @@ continues the bullet above
 - first bullet
 
   continues the bullet above
-
 - second bullet
 ";
         let settings = settings_with_recover_paragraphs_mode(
@@ -5239,6 +5450,14 @@ Capital continuation line.
         s
     }
 
+    fn settings_with_tighten_item_spacing(
+        mode: crate::types::TightenListItemSpacingMode,
+    ) -> FormatterSettings {
+        let mut s = FormatterSettings::default();
+        s.list_normalize.tighten_list_item_spacing = mode;
+        s
+    }
+
     #[test]
     fn tighten_heuristic_collapses_lowercase_continuation() {
         use crate::types::TightenListContinuationsMode;
@@ -5410,6 +5629,150 @@ Capital continuation line.
         let out_explicit = format(
             input,
             &settings_with_tighten(crate::types::TightenListContinuationsMode::Heuristic),
+        );
+        assert_eq!(
+            out_default, out_explicit,
+            "default settings must match explicit heuristic; default=\n{out_default}\nexplicit=\n{out_explicit}"
+        );
+    }
+
+    // ── tighten-list-item-spacing (issue #90) tests ──
+
+    #[test]
+    fn tighten_item_spacing_heuristic_collapses_paragraphs_only_list() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "- first item\n\n- second item\n";
+        let out = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Heuristic),
+        );
+        assert!(
+            !out.contains("first item\n\n- second item"),
+            "heuristic should collapse inter-item blank gap; output:\n{out}"
+        );
+        assert!(
+            out.contains("- first item\n- second item"),
+            "both items must survive; output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tighten_item_spacing_heuristic_preserves_mixed_shape_list() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "\
+- first item
+
+- second item
+  - nested child
+
+- third item
+";
+        let out = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Heuristic),
+        );
+        assert!(
+            out.contains("first item\n\n- second item"),
+            "heuristic must preserve when any sibling item is non-ParagraphsOnly; output:\n{out}"
+        );
+        assert!(
+            out.contains("nested child\n\n- third item"),
+            "heuristic must preserve every inter-item gap in the mixed list; output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tighten_item_spacing_aggressive_ignores_shape_gate() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "\
+- first item
+
+- second item
+  
+  ```js
+  const x = 1;
+  ```
+
+- third item
+";
+        let out = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Aggressive),
+        );
+        assert!(
+            !out.contains("first item\n\n- second item"),
+            "aggressive should collapse first gap; output:\n{out}"
+        );
+        assert!(
+            !out.contains("```\n\n- third item"),
+            "aggressive should collapse second gap; output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tighten_item_spacing_preserves_double_blank_gap() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "- first item\n\n\n- second item\n";
+        let out = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Heuristic),
+        );
+        assert!(
+            out.contains("first item\n\n\n- second item"),
+            "double blank gap should be preserved by the rule; output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tighten_item_spacing_recurses_into_nested_sublists() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "\
+- outer item
+  - inner one
+
+  - inner two
+";
+        let expected = "\
+- outer item
+  - inner one
+  - inner two
+";
+        let out = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Heuristic),
+        );
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn tighten_item_spacing_real_content_three_item_fixture() {
+        let input = "\
+- No `candle`, `ort` / ONNX Runtime, `llama.cpp` / `llama-cpp-2`, `tch` / libtorch, or
+  `rust-bert` dependency in `tauri-app/Cargo.toml` or `tauri-app/core/Cargo.toml`.
+
+- No `gguf` / `.onnx` / `.safetensors` assets in the repo.
+
+- No `tokenizers` / `tantivy` / `lancedb` integration code checked in.
+";
+        let out = format(input, &FormatterSettings::default());
+        assert!(
+            !out.contains("Cargo.toml`.\n\n- No `gguf`"),
+            "first inter-item gap should collapse; output:\n{out}"
+        );
+        assert!(
+            !out.contains("repo.\n\n- No `tokenizers`"),
+            "second inter-item gap should collapse; output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tighten_item_spacing_default_matches_heuristic() {
+        use crate::types::TightenListItemSpacingMode;
+        let input = "- first item\n\n- second item\n";
+        let out_default = format(input, &FormatterSettings::default());
+        let out_explicit = format(
+            input,
+            &settings_with_tighten_item_spacing(TightenListItemSpacingMode::Heuristic),
         );
         assert_eq!(
             out_default, out_explicit,

--- a/crates/mdx-formatter-core/src/types.rs
+++ b/crates/mdx-formatter-core/src/types.rs
@@ -231,9 +231,10 @@ impl Default for AutoDetectIndentSetting {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// List Normalize — config schema (owned by sub-issue #81, filled by #82-#85)
+// List Normalize — config schema (owned by sub-issue #81, filled by #82-#85
+// and issue #90)
 //
-// Four cross-cutting list-normalize rules share one parent struct so the
+// Five cross-cutting list-normalize rules share one parent struct so the
 // schema surface is scannable in one place and downstream rules add behavior
 // (not schema).
 //
@@ -242,6 +243,7 @@ impl Default for AutoDetectIndentSetting {
 //   | Key                                    | Values                             | Default       |
 //   |----------------------------------------|------------------------------------|---------------|
 //   | tighten-list-continuations             | "off" | "heuristic" | "aggressive" | "heuristic"   |
+//   | tighten-list-item-spacing              | "off" | "heuristic" | "aggressive" | "heuristic"   |
 //   | recover-escaped-code-in-lists          | "off" | "safe"      | "aggressive" | "safe"        |
 //   | recover-escaped-tables-in-lists        | "off" | "safe"      | "aggressive" | "safe"        |
 //   | recover-escaped-paragraphs-in-lists    | "off" | "heuristic" | "aggressive" | "off"         |
@@ -257,6 +259,16 @@ impl Default for AutoDetectIndentSetting {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TightenListContinuationsMode {
+    Off,
+    #[default]
+    Heuristic,
+    Aggressive,
+}
+
+/// Tighten-list-item-spacing mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TightenListItemSpacingMode {
     Off,
     #[default]
     Heuristic,
@@ -311,13 +323,14 @@ pub enum ListItemShape {
     Mixed,
 }
 
-/// Parent struct holding all four list-normalize rule settings. Downstream
-/// rules (#82-#85) read their own field here; they do not add keys directly to
+/// Parent struct holding all five list-normalize rule settings. Downstream
+/// rules read their own field here; they do not add keys directly to
 /// `FormatterSettings`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ListNormalizeSettings {
     pub tighten_list_continuations: TightenListContinuationsMode,
+    pub tighten_list_item_spacing: TightenListItemSpacingMode,
     pub recover_escaped_code_in_lists: RecoverEscapedCodeMode,
     pub recover_escaped_tables_in_lists: RecoverEscapedTablesMode,
     pub recover_escaped_paragraphs_in_lists: RecoverEscapedParagraphsMode,
@@ -338,10 +351,11 @@ pub struct FormatterSettings {
     pub error_handling: ErrorHandlingSetting,
     pub auto_detect_indent: AutoDetectIndentSetting,
 
-    /// List normalize rule bundle. All four rules share a flat top-level key
+    /// List normalize rule bundle. All five rules share a flat top-level key
     /// surface in the public config (see `config.rs` for the lift-in/out glue):
-    /// `tighten-list-continuations`, `recover-escaped-code-in-lists`,
-    /// `recover-escaped-tables-in-lists`, `recover-escaped-paragraphs-in-lists`.
+    /// `tighten-list-continuations`, `tighten-list-item-spacing`,
+    /// `recover-escaped-code-in-lists`, `recover-escaped-tables-in-lists`,
+    /// `recover-escaped-paragraphs-in-lists`.
     #[serde(skip)]
     pub list_normalize: ListNormalizeSettings,
 }

--- a/crates/mdx-formatter-napi/src/lib.rs
+++ b/crates/mdx-formatter-napi/src/lib.rs
@@ -7,7 +7,7 @@ fn resolve_settings(settings_json: Option<String>) -> napi::Result<FormatterSett
         let partial: serde_json::Value = serde_json::from_str(&json)
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
         // The TS loader ships an already-merged blob that may include the
-        // four list-normalize top-level kebab-case keys. `from_public_json`
+        // five list-normalize top-level kebab-case keys. `from_public_json`
         // lifts those into `settings.list_normalize` before deserializing
         // the rest via the camelCase serde path. Calling
         // `from_partial_json` directly here silently dropped the keys (see

--- a/crates/mdx-formatter-wasm/src/lib.rs
+++ b/crates/mdx-formatter-wasm/src/lib.rs
@@ -6,7 +6,7 @@ pub fn format(content: &str, settings_json: Option<String>) -> String {
     let mut settings = if let Some(json) = settings_json {
         let partial: serde_json::Value = serde_json::from_str(&json)
             .unwrap_or_default();
-        // Honor the four list-normalize top-level kebab-case keys. See
+        // Honor the five list-normalize top-level kebab-case keys. See
         // `from_public_json` doc in mdx-formatter-core (issue #88).
         mdx_formatter_core::from_public_json(&partial)
     } else {

--- a/doc/src/content/docs/options/index.mdx
+++ b/doc/src/content/docs/options/index.mdx
@@ -65,21 +65,23 @@ Every option can be set via [config file](/docs/overview/configuration) or progr
   },
 
   "tighten-list-continuations": "heuristic",
+  "tighten-list-item-spacing": "heuristic",
   "recover-escaped-code-in-lists": "safe",
   "recover-escaped-tables-in-lists": "safe",
   "recover-escaped-paragraphs-in-lists": "off"
 }
 ```
 
-The last four keys above are the [List Normalize](#list-normalize) rules. Unlike the nested object options above, they are exposed as flat top-level kebab-case string enums.
+The last five keys above are the [List Normalize](#list-normalize) rules. Unlike the nested object options above, they are exposed as flat top-level kebab-case string enums.
 
 ## List Normalize
 
-Four rules that clean up AI-authored list-item content. Each accepts `"off"` to disable. The middle value (`"heuristic"` / `"safe"`) is the conservative trigger; `"aggressive"` drops structural preconditions.
+Five rules that clean up AI-authored list-item content. Each accepts `"off"` to disable. The middle value (`"heuristic"` / `"safe"`) is the conservative trigger; `"aggressive"` drops structural preconditions.
 
 | Key                                                                            | Default       | Purpose                                                                                                        |
 | ------------------------------------------------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | [`tighten-list-continuations`](./tighten-list-continuations)                   | `"heuristic"` | Collapse blank lines inside a list item whose children are continuation paragraphs.                            |
+| [`tighten-list-item-spacing`](./tighten-list-item-spacing)                     | `"heuristic"` | Collapse a single blank line between adjacent sibling list items when the list is safe to tighten.             |
 | [`recover-escaped-code-in-lists`](./recover-escaped-code-in-lists)             | `"safe"`      | Re-indent a fenced code block that escaped to column 0 between two list items.                                 |
 | [`recover-escaped-tables-in-lists`](./recover-escaped-tables-in-lists)         | `"safe"`      | Re-indent a GFM table that escaped to column 0 between two list items.                                         |
 | [`recover-escaped-paragraphs-in-lists`](./recover-escaped-paragraphs-in-lists) | `"off"`       | Re-indent a paragraph that escaped to column 0 between two list items (opt-in — highest false-positive risk).  |

--- a/doc/src/content/docs/options/recover-escaped-paragraphs-in-lists.mdx
+++ b/doc/src/content/docs/options/recover-escaped-paragraphs-in-lists.mdx
@@ -6,7 +6,7 @@ sidebar_position: 23
 
 When an AI author writes a paragraph between two numbered list items at column 0, CommonMark breaks the list at that paragraph. This rule detects the shape and re-indents the paragraph to the preceding item's continuation column so it nests inside the item.
 
-**This rule defaults to `"off"`.** The heuristic for "was this paragraph meant to be a continuation?" carries the highest false-positive risk of the four list-normalize rules, so it ships opt-in.
+**This rule defaults to `"off"`.** The heuristic for "was this paragraph meant to be a continuation?" carries the highest false-positive risk of the five list-normalize rules, so it ships opt-in.
 
 ## Modes
 

--- a/doc/src/content/docs/options/tighten-list-item-spacing.mdx
+++ b/doc/src/content/docs/options/tighten-list-item-spacing.mdx
@@ -1,0 +1,53 @@
+---
+title: tighten-list-item-spacing
+description: Collapse unwanted blank lines between adjacent sibling list items when the list is safe to tighten
+sidebar_position: 21
+---
+
+Collapse the blank line between adjacent sibling `ListItem`s of the same list when the list is safe to tighten. This covers the AI-authored loose-list pattern where each bullet is already a complete paragraph, but extra blank source lines were inserted between items.
+
+## Modes
+
+| Value          | Default | Behavior                                                                                                                                     |
+| -------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"off"`        |         | Never collapse inter-item blank lines.                                                                                                       |
+| `"heuristic"`  |    ✓    | Collapse exactly one blank line between adjacent items only when **every item in the list has shape `ParagraphsOnly`**. Mixed-shape lists stay loose. |
+| `"aggressive"` |         | Drop the all-items shape gate; collapse exactly one blank line between adjacent sibling items regardless of item shape.                      |
+
+Double-blank separators are preserved in both non-off modes.
+
+## Config
+
+```json
+{
+  "tighten-list-item-spacing": "heuristic"
+}
+```
+
+This key sits at the **top level** of the config — not nested under an object. See the [Options overview](./) for the full list-normalize section.
+
+## Example
+
+Before:
+
+````markdown
+- First bullet.
+
+- Second bullet.
+
+- Third bullet.
+````
+
+After (`"heuristic"` — default):
+
+````markdown
+- First bullet.
+- Second bullet.
+- Third bullet.
+````
+
+## Notes
+
+- The rule runs immediately after [`tighten-list-continuations`](./tighten-list-continuations) in the formatter pipeline.
+- The rule is recursive: nested sublists are tightened too when they satisfy the same conditions.
+- The rule is idempotent, including the preserved double-blank case.

--- a/doc/src/content/docs/overview/usage.mdx
+++ b/doc/src/content/docs/overview/usage.mdx
@@ -46,7 +46,7 @@ Before/after snippets are capped at 3 lines each and truncated with `…`
 beyond that. Line numbers are 1-based. The report format matches the
 standalone Rust CLI's output byte-for-byte so tooling can consume either.
 
-Use this to preview what the four [list-normalize](/docs/options/#list-normalize)
+Use this to preview what the five [list-normalize](/docs/options/#list-normalize)
 rules (and any other rule) would change before committing to `--write`.
 
 #### Programmatic dry-run

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -53,9 +53,10 @@ describe('dryRunReport library API', () => {
   it('returns a non-empty report for content with normalizations', () => {
     const entries = dryRunReport(FIXTURE_WITH_CHANGES);
     expect(entries.length).toBeGreaterThan(0);
-    // At least one of the four list-normalize rules must have fired.
+    // At least one of the five list-normalize rules must have fired.
     const ruleNames = new Set(entries.map((e) => e.rule));
     const known = [
+      'tighten-list-item-spacing',
       'recover-escaped-code-in-lists',
       'recover-escaped-tables-in-lists',
       'recover-escaped-paragraphs-in-lists',

--- a/test/fixtures/recover-escaped-paragraphs.expected.md
+++ b/test/fixtures/recover-escaped-paragraphs.expected.md
@@ -1,4 +1,3 @@
 1. first item
    also continues the first
-
 2. second item

--- a/test/fixtures/tighten-item-spacing.expected.md
+++ b/test/fixtures/tighten-item-spacing.expected.md
@@ -1,0 +1,4 @@
+- No `candle`, `ort` / ONNX Runtime, `llama.cpp` / `llama-cpp-2`, `tch` / libtorch, or
+  `rust-bert` dependency in `tauri-app/Cargo.toml` or `tauri-app/core/Cargo.toml`.
+- No `gguf` / `.onnx` / `.safetensors` assets in the repo.
+- No `tokenizers` / `tantivy` / `lancedb` integration code checked in.

--- a/test/fixtures/tighten-item-spacing.md
+++ b/test/fixtures/tighten-item-spacing.md
@@ -1,0 +1,6 @@
+- No `candle`, `ort` / ONNX Runtime, `llama.cpp` / `llama-cpp-2`, `tch` / libtorch, or
+  `rust-bert` dependency in `tauri-app/Cargo.toml` or `tauri-app/core/Cargo.toml`.
+
+- No `gguf` / `.onnx` / `.safetensors` assets in the repo.
+
+- No `tokenizers` / `tantivy` / `lancedb` integration code checked in.

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -13,7 +13,7 @@ async function readFixture(name: string): Promise<string> {
   return fs.readFile(path.join(fixturesDir, name), 'utf-8');
 }
 
-// The four list-normalize rules are exposed as flat top-level kebab-case
+// The five list-normalize rules are exposed as flat top-level kebab-case
 // keys (see `crates/mdx-formatter-core/src/config.rs`). They are not part of
 // the TS `FormatterSettings` shape, so cast at the boundary.
 type ListNormalizeOverride = Record<string, unknown> & DeepPartial<FormatterSettings>;
@@ -985,6 +985,13 @@ This paragraph follows an image.
       expect(result).toBe(expected);
     });
 
+    it('tighten-list-item-spacing: collapses blank gaps between sibling ParagraphsOnly items', async () => {
+      const input = await readFixture('tighten-item-spacing.md');
+      const expected = await readFixture('tighten-item-spacing.expected.md');
+      const result = await format(input);
+      expect(result).toBe(expected);
+    });
+
     it('recover-escaped-code-in-lists: re-indents a col-0 fence between numbered items', async () => {
       const input = await readFixture('recover-escaped-code.md');
       const expected = await readFixture('recover-escaped-code.expected.md');
@@ -1019,7 +1026,7 @@ This paragraph follows an image.
     });
 
     // ── "Formatter is innocent" baseline (epic #80) ─────────────────────────
-    // With all four list-normalize rules set to "off", the loose-shape
+    // With all five list-normalize rules set to "off", the loose-shape
     // continuation-paragraph snippet round-trips byte-identically. This is
     // the repo-local assertion that the formatter does not introduce the
     // blank lines observed in AI-authored content — they must be present in
@@ -1029,6 +1036,7 @@ This paragraph follows an image.
       const result = await format(input, {
         settings: lnSettings({
           'tighten-list-continuations': 'off',
+          'tighten-list-item-spacing': 'off',
           'recover-escaped-code-in-lists': 'off',
           'recover-escaped-tables-in-lists': 'off',
           'recover-escaped-paragraphs-in-lists': 'off',

--- a/test/snapshots/tighten-item-spacing.md
+++ b/test/snapshots/tighten-item-spacing.md
@@ -1,0 +1,4 @@
+- No `candle`, `ort` / ONNX Runtime, `llama.cpp` / `llama-cpp-2`, `tch` / libtorch, or
+  `rust-bert` dependency in `tauri-app/Cargo.toml` or `tauri-app/core/Cargo.toml`.
+- No `gguf` / `.onnx` / `.safetensors` assets in the repo.
+- No `tokenizers` / `tantivy` / `lancedb` integration code checked in.


### PR DESCRIPTION
## Summary
- add the new `tighten-list-item-spacing` list-normalize rule with off/heuristic/aggressive modes
- run it after `tighten-list-continuations`, preserve intentional double-blank separators, and surface dry-run/report coverage
- add fixtures, snapshots, and docs for the new option and update related expectations

## Testing
- cargo test -p mdx-formatter-core
- cargo test -p mdx-formatter-cli dry_run
- pnpm build:rust
- pnpm vitest test/formatter.test.ts test/dry-run.test.ts test/snapshots.test.ts

Closes #90