### PR TITLE
Pin pnpm via packageManager field + add npm provenance to release.yml (#120, #121)

### DIFF
--- a/.github/actions/build-astro/action.yml
+++ b/.github/actions/build-astro/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '22'
-  pnpm-version:
-    description: 'pnpm version to use'
-    required: false
-    default: '10'
   working-directory:
     description: 'Working directory containing the Astro project'
     required: false
@@ -18,10 +14,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # pnpm version comes from the root package.json "packageManager" field.
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
         node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
+      # pnpm version comes from the root package.json "packageManager" field.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -27,7 +27,6 @@ jobs:
         uses: ./.github/actions/build-astro
         with:
           node-version: '22'
-          pnpm-version: '10'
           working-directory: 'doc'
 
       - name: Upload build artifacts

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -27,7 +27,6 @@ jobs:
         uses: ./.github/actions/build-astro
         with:
           node-version: '22'
-          pnpm-version: '10'
           working-directory: 'doc'
 
       - name: Upload build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,16 +89,17 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # OIDC token for npm publish provenance attestation.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Sync platform package versions with root
         shell: bash
         run: node scripts/sync-napi-versions.mjs
+      # pnpm version comes from the root package.json "packageManager" field
+      # (pinned exactly there so publish behavior — workspace: specifier
+      # rewriting — does not drift with the latest pnpm 10.x).
       - uses: pnpm/action-setup@v4
-        with:
-          # Pinned exactly: publish behavior (workspace: specifier rewriting)
-          # must not drift with whatever the latest pnpm 10.x happens to be.
-          version: 10.34.1
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -148,7 +149,7 @@ jobs:
               continue
             fi
             echo "Publishing ${PKG}@${VERSION} (--tag ${DIST_TAG})..."
-            if ! (cd "$dir" && npm publish --access public --tag "$DIST_TAG"); then
+            if ! (cd "$dir" && npm publish --access public --tag "$DIST_TAG" --provenance); then
               # Race tolerance: another run may have published it between the
               # check and the publish. "Now exists" counts as success.
               if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
@@ -183,7 +184,7 @@ jobs:
           echo "Publishing ${PKG}@${VERSION} (--tag ${DIST_TAG})..."
           # pnpm publish (NOT npm publish): rewrites the workspace:X.Y.Z
           # optionalDependencies to exact versions in the packed tarball.
-          if ! pnpm publish --access public --tag "$DIST_TAG" --no-git-checks; then
+          if ! pnpm publish --access public --tag "$DIST_TAG" --no-git-checks --provenance; then
             if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
               echo "${PKG}@${VERSION} appeared during publish — treating as success"
             else

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "packageManager": "pnpm@10.34.1",
   "napi": {
     "binaryName": "mdx-formatter-napi",
     "targets": [


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/mdx-formatter/issues/120
    - https://github.com/Takazudo/mdx-formatter/issues/121

---

## Summary

Two related CI/release-workflow hardening changes, done in one PR because both touch `release.yml`. Closes #120, closes #121.

## #120 — Pin pnpm via the `packageManager` field

Adds `"packageManager": "pnpm@10.34.1"` to the root `package.json` as the single source of truth, and removes every now-redundant explicit pnpm version input. `pnpm/action-setup@v4` reads the `packageManager` field when no `version` is given (and errors if a `version` input disagrees with it — so the inputs had to go). Every workflow now resolves the same exact pnpm instead of floating on the latest `10.x`.

- `ci.yml` — dropped `version: 10`
- `release.yml` — dropped the inline `version: 10.34.1` pin (the field now carries it; the exact-pin guarantee for `workspace:` rewriting is preserved)
- `.github/actions/build-astro/action.yml` — removed the `pnpm-version` input + its use
- `main-deploy.yml`, `pr-preview.yml` — dropped `pnpm-version: '10'` passed to the composite

## #121 — npm provenance in `release.yml`

- Added `id-token: write` to the publish job's `permissions` (was `contents: read`) — the OIDC token provenance attestation needs
- Added `--provenance` to all 5 publishes (4 platform `npm publish` + root `pnpm publish`)

The original "after first successful automated release" gating was waived at the user's request.

## Test Plan

- [x] `pnpm check` / `pnpm build` / `pnpm test` (253 tests) pass locally
- [x] `pnpm install --frozen-lockfile` unaffected by the `packageManager` field
- [x] All 5 modified YAML files parse cleanly; no stray `version`/`pnpm-version` inputs remain
- [x] CI green on this PR — **the "Build Documentation Site" check exercises the modified `build-astro` composite in a real runner**, validating the #120 change in-environment (same composite `main-deploy.yml` uses)
- [ ] **⚠️ Not covered by CI**: `release.yml`'s publish path (including `--provenance`) runs only on tag push. First real test is `/l-make-release next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)