### PR TITLE
Redirect legacy documentation URLs

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -74,6 +74,20 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Deploy legacy Pages redirects
+        run: |
+          WRANGLER_VERSION=$(node -p "require('./doc/package.json').devDependencies.wrangler")
+          npx "wrangler@${WRANGLER_VERSION}" pages deploy doc/legacy-pages \
+            --project-name=mdx-formatter \
+            --branch=main \
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="Redirect legacy documentation URLs: ${GITHUB_SHA}"
+        env:
+          # Retaining the old pages.dev endpoint requires Pages: Edit in
+          # addition to the Workers and zone permissions used above.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
   notify:
     name: Deploy Notification
     needs: [build, deploy]

--- a/doc/legacy-pages/_redirects
+++ b/doc/legacy-pages/_redirects
@@ -1,0 +1,3 @@
+/pj/mdx-formatter https://mdx-formatter.takazudomodular.com/ 301
+/pj/mdx-formatter/* https://mdx-formatter.takazudomodular.com/:splat 301
+/* https://mdx-formatter.takazudomodular.com/:splat 301

--- a/doc/legacy-pages/index.html
+++ b/doc/legacy-pages/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://mdx-formatter.takazudomodular.com/"
+    />
+    <link rel="canonical" href="https://mdx-formatter.takazudomodular.com/" />
+    <title>mdx-formatter documentation moved</title>
+  </head>
+  <body>
+    <p>
+      The documentation moved to
+      <a href="https://mdx-formatter.takazudomodular.com/"
+        >mdx-formatter.takazudomodular.com</a
+      >.
+    </p>
+  </body>
+</html>

--- a/test/doc-redirects.test.js
+++ b/test/doc-redirects.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getLegacyRedirect } from '../worker/index.js';
+
+describe('legacy documentation redirects', () => {
+  it('redirects the old root path to the new origin', () => {
+    expect(getLegacyRedirect('https://takazudomodular.com/pj/mdx-formatter/')).toBe(
+      'https://mdx-formatter.takazudomodular.com/',
+    );
+  });
+
+  it('preserves nested paths and query parameters', () => {
+    expect(
+      getLegacyRedirect('https://takazudomodular.com/pj/mdx-formatter/docs/overview?lang=en'),
+    ).toBe('https://mdx-formatter.takazudomodular.com/docs/overview?lang=en');
+  });
+
+  it('redirects the legacy path when requested on the new hostname', () => {
+    expect(
+      getLegacyRedirect('https://mdx-formatter.takazudomodular.com/pj/mdx-formatter/docs/options'),
+    ).toBe('https://mdx-formatter.takazudomodular.com/docs/options');
+  });
+
+  it('leaves unrelated paths and hosts unchanged', () => {
+    expect(getLegacyRedirect('https://takazudomodular.com/pj/other/')).toBeNull();
+    expect(getLegacyRedirect('https://example.com/pj/mdx-formatter/')).toBeNull();
+  });
+});

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,42 @@
+const NEW_DOC_ORIGIN = 'https://mdx-formatter.takazudomodular.com';
+const LEGACY_PATH_PREFIX = '/pj/mdx-formatter';
+const LEGACY_HOSTS = new Set(['takazudomodular.com', 'mdx-formatter.takazudomodular.com']);
+
+export function getLegacyRedirect(requestUrl) {
+  const url = new URL(requestUrl);
+
+  if (!LEGACY_HOSTS.has(url.hostname)) {
+    return null;
+  }
+
+  const isLegacyPath =
+    url.pathname === LEGACY_PATH_PREFIX || url.pathname.startsWith(`${LEGACY_PATH_PREFIX}/`);
+
+  if (!isLegacyPath) {
+    return null;
+  }
+
+  const destinationPath = url.pathname.slice(LEGACY_PATH_PREFIX.length) || '/';
+  const destination = new URL(destinationPath, NEW_DOC_ORIGIN);
+  destination.search = url.search;
+
+  return destination.toString();
+}
+
+export default {
+  fetch(request, env) {
+    const redirectLocation = getLegacyRedirect(request.url);
+
+    if (redirectLocation) {
+      return Response.redirect(redirectLocation, 301);
+    }
+
+    // This Worker is layered over the parent site's origin only for the
+    // legacy docs route. Defer any non-matching request to that origin.
+    if (new URL(request.url).hostname === 'takazudomodular.com') {
+      return fetch(request);
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,18 +1,28 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "mdx-formatter",
+  "main": "./worker/index.js",
   "compatibility_date": "2026-08-01",
   "workers_dev": true,
   "preview_urls": true,
   "assets": {
     "directory": "./doc/dist",
+    "binding": "ASSETS",
     "not_found_handling": "404-page",
-    "run_worker_first": false,
+    "run_worker_first": ["/pj/mdx-formatter*"],
   },
   "routes": [
     {
       "pattern": "mdx-formatter.takazudomodular.com",
       "custom_domain": true,
     },
+    {
+      "pattern": "takazudomodular.com/pj/mdx-formatter*",
+      "zone_name": "takazudomodular.com",
+    },
   ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
 }


### PR DESCRIPTION
## Summary

- redirect the legacy Cloudflare Pages documentation URL to the new dedicated hostname
- redirect the former parent-site path to the same destination through a narrow Worker route
- preserve nested documentation paths and query strings

## Implementation

- deploy a minimal `_redirects` artifact to the existing `mdx-formatter.pages.dev` project
- add a Worker handler for `takazudomodular.com/pj/mdx-formatter*` while continuing to serve the new site through Workers Static Assets
- cover legacy root, nested path, query-string, and non-match behavior with tests

## Verification

- `pnpm lint`
- `pnpm test` (257 tests)
- `pnpm prettier`
- `pnpm --dir doc exec wrangler deploy --config ../wrangler.jsonc --dry-run`
- local HTTP checks for both legacy routes and the new root site
