### PR TITLE
[doc] reconcile zudo toolchain scaffold (#143)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ AST-based markdown and MDX formatter powered by a Rust engine (via napi-rs). Pub
 - **Test framework**: vitest
 - **Linting**: ESLint (flat config) + Prettier + lefthook (pre-commit hooks)
 - **Build**: `tsc` (output to `dist/`)
-- **Doc site**: zudo-doc 5.2.1 / zfb (workspace in `doc/`; Node.js >= 22)
+- **Doc site**: zudo-doc 5.13.0 / zfb (workspace in `doc/`; Node.js >= 22)
 - **Rust implementation**: Production-ready Rust engine in `crates/` (markdown-rs + napi-rs + WASM)
 
 ## Commands

--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -1,6 +1,6 @@
 # mdx-formatter Documentation Site
 
-Documentation site built with [zudo-doc](https://github.com/zudolab/zudo-doc) 5.2.1 — a zfb-based documentation framework with MDX, Tailwind CSS v4, and Preact islands. This project is intentionally minimal: one config file (`zfb.config.ts`) plus markdown content — layout, chrome, and islands all ship from `@takazudo/zudo-doc` in `node_modules`. Node.js >= 22 is required.
+Documentation site built with [zudo-doc](https://github.com/zudolab/zudo-doc) 5.13.0 — a zfb-based documentation framework with MDX, Tailwind CSS v4, and Preact islands. This project is intentionally minimal: one config file (`zfb.config.ts`) plus markdown content — layout, chrome, and islands all ship from `@takazudo/zudo-doc` in `node_modules`. Node.js >= 22 is required.
 
 ## Tech Stack
 
@@ -20,6 +20,11 @@ Documentation site built with [zudo-doc](https://github.com/zudolab/zudo-doc) 5.
 - `pnpm build` — runs `zfb build` for a static HTML export to `dist/`
 - `pnpm check` — runs `zfb check` for type and content checking
 - `pnpm preview` — runs `zfb preview` to serve the built `dist/`
+
+The 5.13 scaffold's `scripts/check-links.js` is intentionally not adopted in
+this in-place upgrade: strict use would require a separate content/allowlist
+policy for the existing link warnings, while `zfb build` remains the current
+link-validation gate for this site.
 
 The formatter playground loads project-owned WASM files from `public/wasm/`.
 From the repository root, run `pnpm build:wasm:doc` before using the playground

--- a/doc/pages/[locale]/docs/[[...slug]].tsx
+++ b/doc/pages/[locale]/docs/[[...slug]].tsx
@@ -22,6 +22,9 @@
 //
 // docHistory note: same as the default-locale stub — when docHistory is
 // selected, the generator patches this file too.
+// Binding decision: retain this generated static merge as the sole DocHistory
+// path because the host-owned stub shadows the package route; static reachability
+// keeps the island registered.
 
 import type { JSX } from "preact";
 import { routeContext } from "virtual:zudo-doc-route-context";

--- a/doc/pages/docs/[[...slug]].tsx
+++ b/doc/pages/docs/[[...slug]].tsx
@@ -26,6 +26,9 @@
 // DocHistory's chrome-derive default is a no-op stub (unlike
 // DesignTokenPanelBootstrap, which the package auto-defaults), so without
 // that patch the doc-history button never hydrates on this route.
+// Binding decision: retain this generated static merge as the sole DocHistory
+// path because the host-owned stub shadows the package route; static reachability
+// keeps the island registered.
 
 import type { JSX } from "preact";
 import { routeContext } from "virtual:zudo-doc-route-context";


### PR DESCRIPTION
Parent epic: #141

Topic: #143

## Summary

- retain both project-owned dynamic route stubs and their static chrome-binding imports
- document and retain exactly one static DocHistory merge path per stub
- update the two toolchain version references
- explicitly defer the new strict check-links scaffold until existing warnings have a dedicated policy

## Verification

- `pnpm --dir doc check`
- `pnpm --dir doc build` (207 pages)
- bounded `pnpm --dir doc preview` start; wrangler gate passed
