### PR TITLE
[doc] clear documentation build warnings

### DIFF
--- a/doc/src/content/docs-v-0x/architecture/index.mdx
+++ b/doc/src/content/docs-v-0x/architecture/index.mdx
@@ -97,7 +97,7 @@ Rules are applied in order during the operation collection phase. After all oper
 
 ## No Plugin System Needed
 
-The TypeScript formatter originally used 10 remark plugins to work around AST round-trip issues (`preserve-jsx.ts`, `preserve-image-alt.ts`, `fix-autolink-output.ts`, etc.). The hybrid approach — which uses the AST only for analysis, never for output — eliminates the need for these plugins. The Rust implementation validates that 9 of 10 plugins are unnecessary (see [Rust Rewrite: Plugin Validation](rust-rewrite#plugin-validation)).
+The TypeScript formatter originally used 10 remark plugins to work around AST round-trip issues (`preserve-jsx.ts`, `preserve-image-alt.ts`, `fix-autolink-output.ts`, etc.). The hybrid approach — which uses the AST only for analysis, never for output — eliminates the need for these plugins. The Rust implementation validates that 9 of 10 plugins are unnecessary (see [Rust Rewrite: Plugin Validation](rust-rewrite#implemented-formatting-rules-plugin-validation)).
 
 The formatting logic lives in the Rust engine (`crates/mdx-formatter-core/src/formatter.rs`). The TypeScript code in `src/` is a thin wrapper that loads the native module.
 

--- a/doc/src/content/docs/architecture/_category_.json
+++ b/doc/src/content/docs/architecture/_category_.json
@@ -1,1 +1,0 @@
-{"label": "Architecture", "position": 4}

--- a/doc/src/content/docs/architecture/index.mdx
+++ b/doc/src/content/docs/architecture/index.mdx
@@ -97,7 +97,7 @@ Rules are applied in order during the operation collection phase. After all oper
 
 ## No Plugin System Needed
 
-The TypeScript formatter originally used 10 remark plugins to work around AST round-trip issues (`preserve-jsx.ts`, `preserve-image-alt.ts`, `fix-autolink-output.ts`, etc.). The hybrid approach — which uses the AST only for analysis, never for output — eliminates the need for these plugins. The Rust implementation validates that 9 of 10 plugins are unnecessary (see [Rust Rewrite: Plugin Validation](rust-rewrite#plugin-validation)).
+The TypeScript formatter originally used 10 remark plugins to work around AST round-trip issues (`preserve-jsx.ts`, `preserve-image-alt.ts`, `fix-autolink-output.ts`, etc.). The hybrid approach — which uses the AST only for analysis, never for output — eliminates the need for these plugins. The Rust implementation validates that 9 of 10 plugins are unnecessary (see [Rust Rewrite: Plugin Validation](rust-rewrite#implemented-formatting-rules-plugin-validation)).
 
 The formatting logic lives in the Rust engine (`crates/mdx-formatter-core/src/formatter.rs`). The TypeScript code in `src/` is a thin wrapper that loads the native module.
 

--- a/doc/src/content/docs/changelog/_category_.json
+++ b/doc/src/content/docs/changelog/_category_.json
@@ -1,6 +1,0 @@
-{
-  "label": "Changelog",
-  "position": 900,
-  "description": "Release history",
-  "sortOrder": "desc"
-}

--- a/doc/src/content/docs/formatting/_category_.json
+++ b/doc/src/content/docs/formatting/_category_.json
@@ -1,1 +1,0 @@
-{"label": "Formatting", "position": 2}

--- a/doc/src/content/docs/options/_category_.json
+++ b/doc/src/content/docs/options/_category_.json
@@ -1,1 +1,0 @@
-{"label": "Options", "position": 3}

--- a/doc/src/content/docs/options/index.mdx
+++ b/doc/src/content/docs/options/index.mdx
@@ -86,4 +86,4 @@ Five rules that clean up AI-authored list-item content. Each accepts `"off"` to 
 | [`recover-escaped-tables-in-lists`](./recover-escaped-tables-in-lists)         | `"safe"`      | Re-indent a GFM table that escaped to column 0 between two list items.                                         |
 | [`recover-escaped-paragraphs-in-lists`](./recover-escaped-paragraphs-in-lists) | `"off"`       | Re-indent a paragraph that escaped to column 0 between two list items (opt-in — highest false-positive risk).  |
 
-Use [`--dry-run`](../overview/usage#preview-changes-with---dry-run) to preview what each rule would change before committing.
+Use [`--dry-run`](../overview/usage#cli-preview-changes-with---dry-run) to preview what each rule would change before committing.

--- a/doc/src/content/docs/options/recover-escaped-paragraphs-in-lists.mdx
+++ b/doc/src/content/docs/options/recover-escaped-paragraphs-in-lists.mdx
@@ -67,4 +67,4 @@ Output in `"heuristic"` mode is byte-identical — the capital start reads like 
 
 - Non-resuming numbering (e.g. `1. … / 1. …`) disqualifies the paragraph from recovery in every mode.
 - The rule is idempotent and runs **before** [`tighten-list-continuations`](./tighten-list-continuations) in the formatter pipeline.
-- If you're unsure whether this rule is safe for your content, use [`--dry-run`](../overview/usage#preview-changes-with---dry-run) to preview every change.
+- If you're unsure whether this rule is safe for your content, use [`--dry-run`](../overview/usage#cli-preview-changes-with---dry-run) to preview every change.

--- a/doc/src/content/docs/overview/_category_.json
+++ b/doc/src/content/docs/overview/_category_.json
@@ -1,1 +1,0 @@
-{"label": "Overview", "position": 1}

--- a/doc/src/content/docs/playground/_category_.json
+++ b/doc/src/content/docs/playground/_category_.json
@@ -1,1 +1,0 @@
-{"label": "Playground", "position": 7}


### PR DESCRIPTION
## Summary

- repair four stale heading fragments so generated documentation links resolve again
- remove six ignored legacy Docusaurus `_category_.json` files; `zfb.config.ts` remains the explicit navigation source

## Verification

- `pnpm --dir doc check`
- `pnpm --dir doc build` (207 pages; no broken-fragment or ignored-category warnings)
- `pnpm exec prettier --check doc/src/content/docs/architecture/index.mdx doc/src/content/docs-v-0x/architecture/index.mdx doc/src/content/docs/options/index.mdx doc/src/content/docs/options/recover-escaped-paragraphs-in-lists.mdx`

Fixes #147
Fixes #148
