### PR TITLE
[CLI Discovery Fixes] Classify explicit Node operands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,9 @@ import { formatFile, checkFile, dryRunReport } from './index.js';
 import type { DryRunReportEntry } from './index.js';
 import { loadFullConfig } from './load-config.js';
 import type { FormatOptions } from './types.js';
-import { discoverFiles } from './discover.js';
+import { discoverFiles, normalizeOperand } from './discover.js';
+
+const DEFAULT_PATTERNS = ['**/*.{md,mdx}'];
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
   version: string;
@@ -18,7 +20,7 @@ program
   .name('mdx-formatter')
   .description('AST-based markdown and MDX formatter')
   .version(pkg.version)
-  .argument('[patterns...]', 'Glob patterns for files to format', ['**/*.{md,mdx}'])
+  .argument('[patterns...]', 'Glob patterns or explicit files to format')
   .option('-w, --write', 'Write formatted files in place')
   .option('-c, --check', 'Check if files need formatting')
   .option(
@@ -90,16 +92,37 @@ async function main(
   const { settings, excludePatterns } = loadFullConfig(
     options.config ? { config: options.config } : {},
   );
-  const ignorePatterns = [...new Set([...cliIgnorePatterns, ...excludePatterns])];
   const formatOptions: FormatOptions = { settings };
 
-  const uniqueFiles = await discoverFiles(patterns, ignorePatterns);
+  const operands = patterns.length === 0 ? DEFAULT_PATTERNS : patterns;
+  const {
+    files: uniqueFiles,
+    anyMatchedBeforeFilter,
+    badOperands,
+  } = await discoverFiles(operands, { cliIgnorePatterns, excludePatterns });
+
+  if (badOperands.length > 0) {
+    for (const { operand, reason } of badOperands) {
+      if (reason === 'directory') {
+        const globBase = operand.replace(/[\\/]+$/, '');
+        console.error(
+          `${operand}: is a directory (pass a glob such as '${globBase}/**/*.md' to format its contents)`,
+        );
+      } else {
+        console.error(`${operand}: no such file`);
+      }
+    }
+    process.exit(1);
+  }
 
   if (uniqueFiles.length === 0) {
+    const message = anyMatchedBeforeFilter
+      ? 'All matching files were excluded by ignore/exclude patterns — 0 files to process.'
+      : 'No files found matching the patterns.';
     if (options.dryRun) {
-      console.error(chalk.yellow('No files found matching the patterns.'));
+      console.error(chalk.yellow(message));
     } else {
-      console.log(chalk.yellow('No files found matching the patterns.'));
+      console.log(chalk.yellow(message));
     }
     return;
   }
@@ -115,9 +138,10 @@ async function main(
   let errorCount = 0;
 
   for (const file of uniqueFiles) {
+    const ioPath = normalizeOperand(file);
     try {
       if (options.write) {
-        const changed = await formatFile(file, formatOptions);
+        const changed = await formatFile(ioPath, formatOptions);
         if (changed) {
           changedCount++;
           console.log(chalk.green('✓'), chalk.gray(file), chalk.green('formatted'));
@@ -125,7 +149,7 @@ async function main(
           console.log(chalk.gray('○'), chalk.gray(file), chalk.gray('unchanged'));
         }
       } else if (options.check) {
-        const needsFormatting = await checkFile(file, formatOptions);
+        const needsFormatting = await checkFile(ioPath, formatOptions);
         if (needsFormatting) {
           changedCount++;
           console.log(chalk.yellow('⚠'), chalk.gray(file), chalk.yellow('needs formatting'));
@@ -134,7 +158,7 @@ async function main(
         }
       } else {
         // Default: just show what would be done
-        const needsFormatting = await checkFile(file, formatOptions);
+        const needsFormatting = await checkFile(ioPath, formatOptions);
         if (needsFormatting) {
           changedCount++;
           console.log(chalk.blue('→'), chalk.gray(file), chalk.blue('would be formatted'));
@@ -190,9 +214,10 @@ async function runDryRun(files: string[], formatOptions: FormatOptions): Promise
   let filesWithChanges = 0;
 
   for (const file of files) {
+    const ioPath = normalizeOperand(file);
     let content: string;
     try {
-      content = await fs.readFile(file, 'utf-8');
+      content = await fs.readFile(ioPath, 'utf-8');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`${file}: read error: ${message}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,12 +3,12 @@
 import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
 import { program } from 'commander';
-import { glob } from 'glob';
 import chalk from 'chalk';
 import { formatFile, checkFile, dryRunReport } from './index.js';
 import type { DryRunReportEntry } from './index.js';
 import { loadFullConfig } from './load-config.js';
 import type { FormatOptions } from './types.js';
+import { discoverFiles } from './discover.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
   version: string;
@@ -93,18 +93,7 @@ async function main(
   const ignorePatterns = [...new Set([...cliIgnorePatterns, ...excludePatterns])];
   const formatOptions: FormatOptions = { settings };
 
-  // Find all matching files
-  const files: string[] = [];
-  for (const pattern of patterns) {
-    const matches = await glob(pattern, {
-      ignore: ignorePatterns,
-      nodir: true,
-    });
-    files.push(...matches);
-  }
-
-  // Remove duplicates
-  const uniqueFiles = [...new Set(files)];
+  const uniqueFiles = await discoverFiles(patterns, ignorePatterns);
 
   if (uniqueFiles.length === 0) {
     if (options.dryRun) {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,0 +1,19 @@
+import { glob } from 'glob';
+
+export async function discoverFiles(
+  patterns: string[],
+  ignorePatterns: string[],
+): Promise<string[]> {
+  // Find all matching files
+  const files: string[] = [];
+  for (const pattern of patterns) {
+    const matches = await glob(pattern, {
+      ignore: ignorePatterns,
+      nodir: true,
+    });
+    files.push(...matches);
+  }
+
+  // Remove duplicates
+  return [...new Set(files)];
+}

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,19 +1,123 @@
-import { glob } from 'glob';
+import { statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { escape, glob, hasMagic } from 'glob';
 
-export async function discoverFiles(
-  patterns: string[],
-  ignorePatterns: string[],
-): Promise<string[]> {
-  // Find all matching files
-  const files: string[] = [];
-  for (const pattern of patterns) {
-    const matches = await glob(pattern, {
-      ignore: ignorePatterns,
-      nodir: true,
-    });
-    files.push(...matches);
+export interface DiscoveryResult {
+  files: string[];
+  anyMatchedBeforeFilter: boolean;
+  badOperands: Array<{ operand: string; reason: 'missing' | 'directory' }>;
+}
+
+export interface DiscoverOptions {
+  cliIgnorePatterns: string[];
+  excludePatterns: string[];
+  cwd?: string;
+}
+
+export interface ClassifiedOperands {
+  explicitPaths: string[];
+  globPatterns: string[];
+  badOperands: Array<{ operand: string; reason: 'missing' | 'directory' }>;
+}
+
+/** Treat both slash styles as separators, regardless of the host platform. */
+export function normalizeOperand(operand: string): string {
+  return operand.replaceAll('\\', '/');
+}
+
+export function classifyOperands(operands: string[], cwd = process.cwd()): ClassifiedOperands {
+  const explicitPaths: string[] = [];
+  const globPatterns: string[] = [];
+  const badOperands: ClassifiedOperands['badOperands'] = [];
+
+  for (const operand of operands) {
+    const normalized = normalizeOperand(operand);
+    try {
+      const stats = statSync(resolve(cwd, normalized));
+      if (stats.isFile()) {
+        explicitPaths.push(operand);
+      } else if (stats.isDirectory()) {
+        badOperands.push({ operand, reason: 'directory' });
+      } else {
+        badOperands.push({ operand, reason: 'missing' });
+      }
+    } catch {
+      if (hasMagic(normalized, { magicalBraces: true })) {
+        globPatterns.push(operand);
+      } else {
+        badOperands.push({ operand, reason: 'missing' });
+      }
+    }
   }
 
-  // Remove duplicates
-  return [...new Set(files)];
+  return { explicitPaths, globPatterns, badOperands };
+}
+
+async function explicitPathIsIncluded(
+  operand: string,
+  cwd: string,
+  cliIgnorePatterns: string[],
+): Promise<boolean> {
+  if (cliIgnorePatterns.length === 0) return true;
+
+  const absolutePath = resolve(cwd, normalizeOperand(operand));
+  const matches = await glob(escape(absolutePath), {
+    cwd,
+    ignore: cliIgnorePatterns,
+    nodir: true,
+  });
+  return matches.length > 0;
+}
+
+export async function discoverFiles(
+  operands: string[],
+  options: DiscoverOptions,
+): Promise<DiscoveryResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const { explicitPaths, globPatterns, badOperands } = classifyOperands(operands, cwd);
+  const filesByAbsolutePath = new Map<string, string>();
+  let anyMatchedBeforeFilter = explicitPaths.length > 0;
+
+  // Seed explicit paths first so their spelling and filter-bypass semantics win
+  // when a later glob resolves to the same file.
+  for (const operand of explicitPaths) {
+    if (await explicitPathIsIncluded(operand, cwd, options.cliIgnorePatterns)) {
+      filesByAbsolutePath.set(resolve(cwd, normalizeOperand(operand)), operand);
+    }
+  }
+
+  const globIgnorePatterns = [
+    ...new Set([...options.cliIgnorePatterns, ...options.excludePatterns]),
+  ];
+  for (const originalPattern of globPatterns) {
+    const pattern = normalizeOperand(originalPattern);
+    const matches = await glob(pattern, {
+      cwd,
+      ignore: globIgnorePatterns,
+      nodir: true,
+    });
+
+    if (matches.length > 0) {
+      anyMatchedBeforeFilter = true;
+    } else if (globIgnorePatterns.length > 0) {
+      // D4 needs only the existence of a pre-filter match, never an exact
+      // count. The follow-up gitignore work replaces this fallback with its
+      // pruning-aware ignore callbacks.
+      const unfilteredMatches = await glob(pattern, { cwd, nodir: true });
+      anyMatchedBeforeFilter ||= unfilteredMatches.length > 0;
+    }
+
+    for (const match of matches) {
+      const absolutePath = resolve(cwd, normalizeOperand(match));
+      if (!filesByAbsolutePath.has(absolutePath)) {
+        filesByAbsolutePath.set(absolutePath, match);
+      }
+    }
+  }
+
+  return {
+    files: [...filesByAbsolutePath.values()],
+    anyMatchedBeforeFilter,
+    badOperands,
+  };
 }

--- a/test/discover.test.ts
+++ b/test/discover.test.ts
@@ -1,0 +1,265 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { classifyOperands, discoverFiles } from '../src/discover.js';
+import { runCli } from './test-helpers.js';
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'mdx-discover-'));
+}
+
+async function writeFile(root: string, relativePath: string, content = '# Title\n'): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, content, 'utf-8');
+}
+
+describe('classifyOperands', () => {
+  it('stats operands before checking glob magic and reports every bad operand', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'plain.md');
+    await writeFile(cwd, 'a[1].md');
+    await writeFile(cwd, '.claude/skills/x/SKILL.md');
+    await fs.mkdir(path.join(cwd, 'docs'));
+    await fs.symlink('plain.md', path.join(cwd, 'linked.md'));
+    await fs.symlink('absent.md', path.join(cwd, 'dangling.md'));
+
+    const result = classifyOperands(
+      [
+        'plain.md',
+        'a[1].md',
+        'a{b,c}.md',
+        '**/*.md',
+        'docs',
+        'nope.md',
+        'linked.md',
+        'dangling.md',
+        '.claude/skills/x/SKILL.md',
+      ],
+      cwd,
+    );
+
+    expect(result.explicitPaths).toEqual([
+      'plain.md',
+      'a[1].md',
+      'linked.md',
+      '.claude/skills/x/SKILL.md',
+    ]);
+    expect(result.globPatterns).toEqual(['a{b,c}.md', '**/*.md']);
+    expect(result.badOperands).toEqual([
+      { operand: 'docs', reason: 'directory' },
+      { operand: 'nope.md', reason: 'missing' },
+      { operand: 'dangling.md', reason: 'missing' },
+    ]);
+  });
+
+  it('accepts Windows separators while preserving the operand spelling', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    expect(classifyOperands([operand], cwd).explicitPaths).toEqual([operand]);
+  });
+});
+
+describe('discoverFiles', () => {
+  it('lets explicit paths bypass config exclude and gives them dedupe precedence', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await discoverFiles(['foo.md', '*.md'], {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: ['foo.md'],
+    });
+
+    expect(result.files).toEqual(['foo.md']);
+    expect(result.anyMatchedBeforeFilter).toBe(true);
+    expect(result.badOperands).toEqual([]);
+  });
+
+  it('applies CLI ignore to explicit paths', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await discoverFiles(['foo.md'], {
+      cwd,
+      cliIgnorePatterns: ['foo.md'],
+      excludePatterns: [],
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.anyMatchedBeforeFilter).toBe(true);
+  });
+
+  it('distinguishes an excluded glob match from a glob with no matches', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    const options = {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: ['tests/**'],
+    };
+
+    const excluded = await discoverFiles(['tests/**/*.md'], options);
+    const unmatched = await discoverFiles(['missing/**/*.md'], options);
+
+    expect(excluded.files).toEqual([]);
+    expect(excluded.anyMatchedBeforeFilter).toBe(true);
+    expect(unmatched.files).toEqual([]);
+    expect(unmatched.anyMatchedBeforeFilter).toBe(false);
+  });
+
+  it('preserves Windows spelling for an explicit result', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    const result = await discoverFiles([operand], {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: [],
+    });
+
+    expect(result.files).toEqual([operand]);
+  });
+});
+
+describe('CLI discovery', () => {
+  it.each([
+    ['.claude/skills/example/SKILL.md', '.claude/**'],
+    ['tests/foo.md', 'tests/**'],
+  ])(
+    'checks explicit %s despite config exclude',
+    async (operand, exclude) => {
+      const cwd = await makeTempDir();
+      await writeFile(cwd, operand);
+      await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude }));
+
+      const result = await runCli(['--check', operand], { cwd });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Processing 1 file(s)...');
+      expect(result.stdout).toContain(operand);
+      expect(result.stdout).not.toContain('No files found');
+    },
+    30_000,
+  );
+
+  it('keeps explicit discovery unchanged with an empty exclude', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: [] }));
+
+    const result = await runCli(['--check', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+  }, 30_000);
+
+  it('gives --write explicit paths the config-exclude bypass', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['foo.md'] }));
+
+    const result = await runCli(['--write', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+  }, 30_000);
+
+  it('keeps CLI ignore authoritative for explicit paths', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await runCli(['--check', 'foo.md', '--ignore', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('reports when config exclude filters every glob match', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['tests/**'] }));
+
+    const result = await runCli(['--check', 'tests/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('writes the excluded-zero message only to stderr in dry-run mode', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['tests/**'] }));
+
+    const result = await runCli(['--dry-run', 'tests/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('reports no matches separately', async () => {
+    const cwd = await makeTempDir();
+
+    const result = await runCli(['--check', 'missing/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('No files found matching the patterns.');
+  }, 30_000);
+
+  it('applies default patterns only when no operands were supplied', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'default.md');
+
+    const result = await runCli(['--check'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+    expect(result.stdout).toContain('default.md');
+  }, 30_000);
+
+  it('reports all bad operands and never processes the valid subset', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'valid.md');
+    await fs.mkdir(path.join(cwd, 'docs'));
+
+    const result = await runCli(['--check', 'valid.md', 'nope.md', 'docs'], { cwd });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('nope.md: no such file');
+    expect(result.stderr).toContain(
+      "docs: is a directory (pass a glob such as 'docs/**/*.md' to format its contents)",
+    );
+    expect(result.stdout).not.toContain('Processing');
+  }, 30_000);
+
+  it('treats bad dry-run operands as usage errors', async () => {
+    const cwd = await makeTempDir();
+
+    const result = await runCli(['--dry-run', 'nope.md'], { cwd });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('nope.md: no such file');
+  }, 30_000);
+
+  it('processes Windows-separated explicit paths and preserves their output spelling', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    const result = await runCli(['--check', operand], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(operand);
+  }, 30_000);
+});

--- a/test/discover.test.ts
+++ b/test/discover.test.ts
@@ -79,13 +79,16 @@ describe('discoverFiles', () => {
     expect(result.badOperands).toEqual([]);
   });
 
-  it('applies CLI ignore to explicit paths', async () => {
+  it.each([
+    ['foo.md', 'foo.md'],
+    ['tests/foo.md', 'tests/**'],
+  ])('applies CLI ignore to explicit path %s with %s', async (operand, ignorePattern) => {
     const cwd = await makeTempDir();
-    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, operand);
 
-    const result = await discoverFiles(['foo.md'], {
+    const result = await discoverFiles([operand], {
       cwd,
-      cliIgnorePatterns: ['foo.md'],
+      cliIgnorePatterns: [ignorePattern],
       excludePatterns: [],
     });
 

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -10,18 +10,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { dryRunReport, format } from '../src/index.js';
-
-const execFileP = promisify(execFile);
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliEntry = path.resolve(__dirname, '../src/cli.ts');
+import { runCli } from './test-helpers.js';
 
 async function mkTmp(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'mdx-dry-run-'));
@@ -116,22 +109,6 @@ describe('dryRunReport library API', () => {
 });
 
 describe('CLI --dry-run flag', () => {
-  async function runCli(args: string[]): Promise<{
-    stdout: string;
-    stderr: string;
-    code: number;
-  }> {
-    try {
-      const { stdout, stderr } = await execFileP('npx', ['tsx', cliEntry, ...args], {
-        cwd: path.resolve(__dirname, '..'),
-      });
-      return { stdout, stderr, code: 0 };
-    } catch (err) {
-      const e = err as { stdout?: string; stderr?: string; code?: number };
-      return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: e.code ?? 1 };
-    }
-  }
-
   it('reports changes, leaves file byte-identical, exits 0', async () => {
     const dir = await mkTmp();
     const file = path.join(dir, 'sample.md');

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -6,7 +6,35 @@
  * need the original component names to verify behavior.
  */
 
+import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import type { DeepPartial, FormatterSettings } from '../src/types.js';
+
+const execFileP = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tsxEntry = fileURLToPath(import.meta.resolve('tsx/cli'));
+const cliEntry = path.resolve(repoRoot, 'src/cli.ts');
+
+export async function runCli(
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(process.execPath, [tsxEntry, cliEntry, ...args], {
+      cwd: options.cwd ?? repoRoot,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (error) {
+    const result = error as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      code: result.code ?? 1,
+    };
+  }
+}
 
 export const testSettings: DeepPartial<FormatterSettings> = {
   addEmptyLinesInBlockJsx: {


### PR DESCRIPTION
Parent: #156

Implements #157.

## Summary
- extracts Node file discovery into `src/discover.ts`
- classifies operands stat-first with `hasMagic(..., { magicalBraces: true })`
- lets explicit files bypass config `exclude` while retaining CLI `--ignore`
- distinguishes no matches from fully filtered matches and reports all bad operands
- adds arbitrary-cwd CLI helpers and discovery regression coverage

## Validation
- `pnpm test` (276 tests)
- `pnpm lint`
- `pnpm build`
- foreground worker review
