### PR TITLE
[CLI Discovery Fixes] Honor gitignore in Node discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +161,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +243,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +281,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -314,6 +378,7 @@ dependencies = [
  "clap",
  "colored",
  "glob",
+ "ignore",
  "mdx-formatter-core",
 ]
 
@@ -472,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -511,6 +576,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -641,6 +715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +819,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mdx-formatter-cli/Cargo.toml
+++ b/crates/mdx-formatter-cli/Cargo.toml
@@ -12,4 +12,5 @@ path = "src/main.rs"
 mdx-formatter-core = { path = "../mdx-formatter-core" }
 clap = { version = "4", features = ["derive"] }
 glob = "0.3"
+ignore = "0.4"
 colored = "2"

--- a/crates/mdx-formatter-cli/src/main.rs
+++ b/crates/mdx-formatter-cli/src/main.rs
@@ -1,13 +1,15 @@
 use clap::Parser;
 use colored::Colorize;
 use glob::glob;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::WalkBuilder;
 use mdx_formatter_core::{
     load_full_config, try_format, try_format_with_sink, FullConfig, ReportEntry, VecSink,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process;
 
 /// AST-based markdown and MDX formatter
@@ -15,7 +17,6 @@ use std::process;
 #[command(name = "mdx-formatter", version, about)]
 struct Cli {
     /// Glob patterns for files to format
-    #[arg(default_values_t = vec!["**/*.md".to_string(), "**/*.mdx".to_string()])]
     patterns: Vec<String>,
 
     /// Write formatted files in place
@@ -39,16 +40,95 @@ struct Cli {
     config: Option<String>,
 
     /// Comma-separated patterns to ignore
-    #[arg(long, default_value = "node_modules/**,dist/**,build/**,.git/**,worktrees/**")]
+    #[arg(
+        long,
+        default_value = "node_modules/**,dist/**,build/**,.git/**,worktrees/**"
+    )]
     ignore: String,
+
+    /// Read additional ignore rules from a file (repeatable)
+    #[arg(long = "ignore-path", value_name = "FILE")]
+    ignore_paths: Vec<String>,
+
+    /// Do not automatically load .gitignore files
+    #[arg(long)]
+    no_gitignore: bool,
 }
 
-/// Normalize a path string: strip leading "./" so glob patterns match consistently
-fn normalize_path(path: &str) -> &str {
-    path.strip_prefix("./").unwrap_or(path)
+#[derive(Debug)]
+struct DiscoveredFile {
+    path: PathBuf,
+    display: String,
 }
 
-/// Compile ignore patterns once, silently skipping invalid ones
+#[derive(Default)]
+struct DiscoveryResult {
+    files: Vec<DiscoveredFile>,
+    had_matches: bool,
+    had_filtered_matches: bool,
+}
+
+/// Normalize separators for matching. The original operand is retained for diagnostics.
+fn normalize_operand(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn lexical_absolute(cwd: &Path, path: &Path) -> PathBuf {
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn matching_path(path: &Path, cwd: &Path) -> String {
+    let relative = path.strip_prefix(cwd).unwrap_or(path);
+    relative.to_string_lossy().replace('\\', "/")
+}
+
+fn pattern_is_within_cwd(pattern: &str, cwd: &Path) -> bool {
+    let path = Path::new(pattern);
+    if path.is_absolute() {
+        let cwd = cwd.to_string_lossy().replace('\\', "/");
+        return pattern == cwd || pattern.starts_with(&format!("{cwd}/"));
+    }
+    !path
+        .components()
+        .any(|component| component == Component::ParentDir)
+}
+
+/// Rust's glob crate deliberately has no brace expansion. Consequently `{` is
+/// not magic here: a missing `a{b,c}.md` is reported as a missing literal.
+fn has_glob_magic(operand: &str) -> bool {
+    let mut escaped = false;
+    for ch in operand.chars() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if matches!(ch, '*' | '?' | '[') {
+            return true;
+        }
+    }
+    false
+}
+
+/// Compile CLI/config patterns once, silently skipping invalid ones (legacy behavior).
 fn compile_ignore_patterns(patterns: &[String]) -> Vec<glob::Pattern> {
     patterns
         .iter()
@@ -63,37 +143,267 @@ fn is_ignored(normalized_path: &str, compiled_patterns: &[glob::Pattern]) -> boo
         .any(|pat| pat.matches(normalized_path))
 }
 
-/// Collect files matching the given patterns, excluding ignored ones
-fn collect_files(patterns: &[String], ignore_patterns: &[String]) -> Vec<PathBuf> {
-    let compiled = compile_ignore_patterns(ignore_patterns);
+struct GitignoreCache {
+    cwd: PathBuf,
+    matchers: HashMap<PathBuf, Option<Gitignore>>,
+}
+
+impl GitignoreCache {
+    fn new(cwd: PathBuf) -> Self {
+        Self {
+            cwd,
+            matchers: HashMap::new(),
+        }
+    }
+
+    fn matcher(&mut self, directory: &Path) -> Option<&Gitignore> {
+        self.matchers
+            .entry(directory.to_path_buf())
+            .or_insert_with(|| {
+                let path = directory.join(".gitignore");
+                if !path.is_file() {
+                    return None;
+                }
+                let mut builder = GitignoreBuilder::new(directory);
+                if builder.case_insensitive(false).is_err() {
+                    return None;
+                }
+                let _ = builder.add(path);
+                builder.build().ok()
+            });
+        self.matchers.get(directory).and_then(Option::as_ref)
+    }
+
+    fn is_ignored(&mut self, path: &Path) -> bool {
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+        if !parent.starts_with(&self.cwd) {
+            return false;
+        }
+
+        let directories: Vec<PathBuf> = parent
+            .ancestors()
+            .take_while(|directory| directory.starts_with(&self.cwd))
+            .map(Path::to_path_buf)
+            .collect();
+        let mut ignored = false;
+        for directory in directories.iter().rev() {
+            if let Some(matcher) = self.matcher(directory) {
+                let relative = path.strip_prefix(directory).unwrap_or(path);
+                let matched = matcher.matched_path_or_any_parents(relative, false);
+                if matched.is_ignore() {
+                    ignored = true;
+                } else if matched.is_whitelist() {
+                    ignored = false;
+                }
+            }
+        }
+        ignored
+    }
+}
+
+fn compile_ignore_file(original: &str, cwd: &Path) -> Result<(PathBuf, Gitignore), String> {
+    let normalized = normalize_operand(original);
+    let absolute = lexical_absolute(cwd, Path::new(&normalized));
+    let directory = absolute.parent().unwrap_or(cwd);
+    let mut builder = GitignoreBuilder::new(directory);
+    builder
+        .case_insensitive(false)
+        .map_err(|error| format!("{}: {}", original, error))?;
+    if let Some(error) = builder.add(&absolute) {
+        return Err(format!("{}: {}", original, error));
+    }
+    builder
+        .build()
+        .map(|matcher| (directory.to_path_buf(), matcher))
+        .map_err(|error| format!("{}: {}", original, error))
+}
+
+fn ignored_by_files(path: &Path, matchers: &[(PathBuf, Gitignore)]) -> bool {
+    let mut ignored = false;
+    for (directory, matcher) in matchers {
+        let Ok(relative) = path.strip_prefix(directory) else {
+            continue;
+        };
+        let matched = matcher.matched_path_or_any_parents(relative, false);
+        if matched.is_ignore() {
+            ignored = true;
+        } else if matched.is_whitelist() {
+            ignored = false;
+        }
+    }
+    ignored
+}
+
+fn collect_files(
+    operands: &[String],
+    cli_ignore_patterns: &[String],
+    config_exclude_patterns: &[String],
+    ignore_files: &[(PathBuf, Gitignore)],
+    use_gitignore: bool,
+) -> Result<DiscoveryResult, Vec<String>> {
+    let cwd = std::env::current_dir().map_err(|error| vec![error.to_string()])?;
+    let cli_ignores = compile_ignore_patterns(cli_ignore_patterns);
+    let config_excludes = compile_ignore_patterns(config_exclude_patterns);
+    let mut gitignores = GitignoreCache::new(cwd.clone());
+    let mut errors = Vec::new();
+    let mut explicit = Vec::new();
+    let mut patterns = Vec::new();
+
+    for original in operands {
+        let normalized = normalize_operand(original);
+        let absolute = lexical_absolute(&cwd, Path::new(&normalized));
+        match fs::metadata(&absolute) {
+            Ok(metadata) if metadata.is_file() => explicit.push((absolute, original.clone())),
+            Ok(metadata) if metadata.is_dir() => errors.push(format!(
+                "{}: is a directory (pass a glob such as '{}/**/*.md' to format its contents)",
+                original,
+                original.trim_end_matches(['/', '\\'])
+            )),
+            Ok(_) => errors.push(format!("{}: no such file", original)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if has_glob_magic(&normalized) {
+                    patterns.push(normalized);
+                } else {
+                    errors.push(format!("{}: no such file", original));
+                }
+            }
+            Err(error) => errors.push(format!("{}: {}", original, error)),
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    let mut result = DiscoveryResult::default();
     let mut seen = HashSet::new();
-    let mut files = Vec::new();
 
-    for pattern in patterns {
+    // Explicit operands are inserted first so they win deduplication against glob matches.
+    for (path, display) in explicit {
+        result.had_matches = true;
+        let normalized = matching_path(&path, &cwd);
+        if is_ignored(&normalized, &cli_ignores) || ignored_by_files(&path, ignore_files) {
+            result.had_filtered_matches = true;
+        } else if seen.insert(path.clone()) {
+            result.files.push(DiscoveredFile { path, display });
+        }
+    }
+
+    let compiled_patterns: Vec<(String, glob::Pattern)> = patterns
+        .iter()
+        .filter(|pattern| pattern_is_within_cwd(pattern, &cwd))
+        .filter_map(|pattern| {
+            glob::Pattern::new(pattern)
+                .ok()
+                .map(|compiled| (pattern.clone(), compiled))
+        })
+        .collect();
+
+    // WalkBuilder prunes ignored directories while loading only per-tree .gitignore
+    // files. Explicitly disable every additional ignore source that the Node CLI
+    // does not consult.
+    let mut walker = WalkBuilder::new(&cwd);
+    walker
+        .hidden(false)
+        .ignore(false)
+        .git_ignore(use_gitignore)
+        .git_global(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false);
+    for entry in walker.build().filter_map(Result::ok) {
+        let Some(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() && !entry.path().is_file() {
+            continue;
+        }
+        let absolute = lexical_absolute(&cwd, entry.path());
+        let relative = matching_path(&absolute, &cwd);
+        let matched_pattern = compiled_patterns.iter().find(|(source, compiled)| {
+            if Path::new(source).is_absolute() {
+                compiled.matches(&absolute.to_string_lossy().replace('\\', "/"))
+            } else {
+                compiled.matches(&relative)
+            }
+        });
+        let Some((source, _)) = matched_pattern else {
+            continue;
+        };
+        result.had_matches = true;
+        if seen.contains(&absolute) {
+            continue;
+        }
+        let filtered = is_ignored(&relative, &cli_ignores)
+            || is_ignored(&relative, &config_excludes)
+            || ignored_by_files(&absolute, ignore_files);
+        if filtered {
+            result.had_filtered_matches = true;
+        } else {
+            seen.insert(absolute.clone());
+            result.files.push(DiscoveredFile {
+                path: absolute.clone(),
+                display: if Path::new(source).is_absolute() {
+                    absolute.to_string_lossy().into_owned()
+                } else {
+                    relative
+                },
+            });
+        }
+    }
+
+    // Patterns rooted outside cwd cannot be served by the cwd pruning walk.
+    // Preserve the CLI's existing support for those operands with glob's
+    // no-follow traversal; cwd .gitignore files intentionally do not apply.
+    for pattern in patterns
+        .iter()
+        .filter(|pattern| !pattern_is_within_cwd(pattern, &cwd))
+    {
         if let Ok(entries) = glob(pattern) {
-            for entry in entries.flatten() {
-                // Skip directories
-                if entry.is_dir() {
+            for entry in entries.flatten().filter(|entry| entry.is_file()) {
+                result.had_matches = true;
+                let absolute = lexical_absolute(&cwd, &entry);
+                if seen.contains(&absolute) {
                     continue;
                 }
-
-                let path_str = entry.to_string_lossy().to_string();
-                let normalized = normalize_path(&path_str).to_string();
-
-                // Skip ignored paths
-                if is_ignored(&normalized, &compiled) {
-                    continue;
-                }
-
-                // Deduplicate by normalized path
-                if seen.insert(normalized) {
-                    files.push(entry);
+                let normalized = matching_path(&absolute, &cwd);
+                let filtered = is_ignored(&normalized, &cli_ignores)
+                    || is_ignored(&normalized, &config_excludes)
+                    || ignored_by_files(&absolute, ignore_files);
+                if filtered {
+                    result.had_filtered_matches = true;
+                } else {
+                    seen.insert(absolute.clone());
+                    result.files.push(DiscoveredFile {
+                        path: absolute,
+                        display: entry.to_string_lossy().into_owned(),
+                    });
                 }
             }
         }
     }
 
-    files
+    // The pruning walk cannot yield a file hidden by .gitignore. Probe only
+    // until the first such match so D4 can distinguish "no match" from "all
+    // filtered" without computing or reporting a pre-filter count.
+    if use_gitignore && !result.had_matches {
+        'patterns: for pattern in patterns {
+            if let Ok(entries) = glob(&pattern) {
+                for entry in entries.flatten() {
+                    if entry.is_file() {
+                        let absolute = lexical_absolute(&cwd, &entry);
+                        if gitignores.is_ignored(&absolute) {
+                            result.had_matches = true;
+                            result.had_filtered_matches = true;
+                            break 'patterns;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(result)
 }
 
 /// Render one ReportEntry to `stderr` in the stable `--dry-run` format.
@@ -143,26 +453,66 @@ fn main() {
     // Load config using the core library's 3-layer merge
     let loaded: FullConfig = load_full_config(cli.config.as_deref(), None);
 
-    // Merge CLI ignore patterns with config exclude patterns
-    let mut all_ignore: Vec<String> = cli
+    let cli_ignore: Vec<String> = cli
         .ignore
         .split(',')
         .map(|s| s.trim().to_string())
         .collect();
-    for pattern in &loaded.exclude_patterns {
-        if !all_ignore.contains(pattern) {
-            all_ignore.push(pattern.clone());
+
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(error) => {
+            eprintln!("{}", error);
+            process::exit(1);
+        }
+    };
+    let mut ignore_files = Vec::new();
+    let mut ignore_file_errors = Vec::new();
+    for path in &cli.ignore_paths {
+        match compile_ignore_file(path, &cwd) {
+            Ok(matcher) => ignore_files.push(matcher),
+            Err(error) => ignore_file_errors.push(error),
         }
     }
+    if !ignore_file_errors.is_empty() {
+        for error in ignore_file_errors {
+            eprintln!("{}", error);
+        }
+        process::exit(1);
+    }
 
-    // Collect files
-    let files = collect_files(&cli.patterns, &all_ignore);
+    let patterns = if cli.patterns.is_empty() {
+        vec!["**/*.md".to_string(), "**/*.mdx".to_string()]
+    } else {
+        cli.patterns.clone()
+    };
+    let discovery = match collect_files(
+        &patterns,
+        &cli_ignore,
+        &loaded.exclude_patterns,
+        &ignore_files,
+        !cli.no_gitignore,
+    ) {
+        Ok(discovery) => discovery,
+        Err(errors) => {
+            for error in errors {
+                eprintln!("{}", error);
+            }
+            process::exit(1);
+        }
+    };
+    let files = discovery.files;
 
     if files.is_empty() {
-        if cli.dry_run {
-            eprintln!("{}", "No files found matching the patterns.".yellow());
+        let message = if discovery.had_matches && discovery.had_filtered_matches {
+            "All matching files were excluded by ignore/exclude patterns — 0 files to process."
         } else {
-            println!("{}", "No files found matching the patterns.".yellow());
+            "No files found matching the patterns."
+        };
+        if cli.dry_run {
+            eprintln!("{}", message.yellow());
+        } else {
+            println!("{}", message.yellow());
         }
         return;
     }
@@ -181,9 +531,9 @@ fn main() {
     let mut error_count = 0u32;
 
     for file in &files {
-        let path_str = file.to_string_lossy();
+        let path_str = &file.display;
 
-        match fs::read_to_string(file) {
+        match fs::read_to_string(&file.path) {
             Ok(content) => {
                 let formatted = match try_format(&content, &loaded.settings) {
                     Ok(result) => result,
@@ -202,7 +552,7 @@ fn main() {
 
                 if cli.write {
                     if needs_formatting {
-                        if let Err(e) = fs::write(file, &formatted) {
+                        if let Err(e) = fs::write(&file.path, &formatted) {
                             error_count += 1;
                             eprintln!(
                                 "{} {} {}",
@@ -308,10 +658,7 @@ fn main() {
     }
 
     if error_count > 0 {
-        eprintln!(
-            "{}",
-            format!("✗ {} error(s) occurred", error_count).red()
-        );
+        eprintln!("{}", format!("✗ {} error(s) occurred", error_count).red());
         process::exit(1);
     }
 
@@ -324,15 +671,15 @@ fn main() {
 /// to disk. Always exits 0. Errors reading/parsing individual files are
 /// reported as stderr lines but do NOT change the exit code — dry-run is an
 /// audit tool and must not fail CI when a file is malformed.
-fn run_dry_run(files: &[PathBuf], loaded: &FullConfig) {
+fn run_dry_run(files: &[DiscoveredFile], loaded: &FullConfig) {
     let stderr = io::stderr();
     let mut err = stderr.lock();
     let mut total_entries = 0usize;
     let mut files_with_changes = 0usize;
 
     for file in files {
-        let path_str = file.to_string_lossy();
-        let content = match fs::read_to_string(file) {
+        let path_str = &file.display;
+        let content = match fs::read_to_string(&file.path) {
             Ok(c) => c,
             Err(e) => {
                 let _ = writeln!(err, "{}: read error: {}", path_str, e);
@@ -356,7 +703,7 @@ fn run_dry_run(files: &[PathBuf], loaded: &FullConfig) {
         files_with_changes += 1;
         for entry in &sink.entries {
             total_entries += 1;
-            let _ = write_report_entry(&mut err, &path_str, entry);
+            let _ = write_report_entry(&mut err, path_str, entry);
         }
     }
 

--- a/crates/mdx-formatter-cli/tests/discovery.rs
+++ b/crates/mdx-formatter-cli/tests/discovery.rs
@@ -1,0 +1,336 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mdx-formatter"))
+}
+
+fn tmpdir() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let path = env::temp_dir().join(format!(
+        "mdx-formatter-discovery-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(cli_bin())
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn nested_gitignore_hides_generated_mdx_issue_140() {
+    let root = tmpdir();
+    write(&root, "docs/.gitignore", "generated/\n");
+    write(&root, "docs/generated/page.mdx", "# hidden\n");
+
+    let output = run(&root, &["--check", "**/*.mdx"]);
+    assert!(output.status.success());
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+
+    let output = run(&root, &["--check", "--no-gitignore", "**/*.mdx"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_dot_path_bypasses_config_exclude_issue_123_cases_1_and_2() {
+    let root = tmpdir();
+    write(&root, ".claude/skills/example/SKILL.md", "# test\n");
+    write(
+        &root,
+        ".mdx-formatter.json",
+        r#"{"exclude":[".claude/**"]}"#,
+    );
+
+    let output = run(&root, &["--check", ".claude/skills/example/SKILL.md"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+
+    write(&root, ".mdx-formatter.json", r#"{"exclude":[]}"#);
+    let output = run(&root, &["--check", ".claude/skills/example/SKILL.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_plain_path_bypasses_config_exclude_issue_123_case_3() {
+    let root = tmpdir();
+    write(&root, "tests/foo.md", "# test\n");
+    write(&root, ".mdx-formatter.json", r#"{"exclude":["tests/**"]}"#);
+
+    let output = run(&root, &["--check", "tests/foo.md"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn glob_matches_still_honor_config_exclude() {
+    let root = tmpdir();
+    write(&root, "tests/foo.md", "# test\n");
+    write(&root, ".mdx-formatter.json", r#"{"exclude":["tests/**"]}"#);
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn nested_gitignore_deeper_rule_wins_and_negation_reincludes_child() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "docs/generated/*\n");
+    write(&root, "docs/.gitignore", "!generated/keep.md\n");
+    write(&root, "docs/generated/drop.md", "# drop\n");
+    write(&root, "docs/generated/keep.md", "# keep\n");
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert!(out.contains("docs/generated/keep.md"), "{out}");
+    assert!(!out.contains("docs/generated/drop.md"), "{out}");
+}
+
+#[test]
+fn gitignore_negation_uses_file_pattern_not_ignored_directory() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "generated/*\n!generated/keep.md\n");
+    write(&root, "generated/drop.md", "# drop\n");
+    write(&root, "generated/keep.md", "# keep\n");
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("generated/keep.md"), "{out}");
+    assert!(!out.contains("generated/drop.md"), "{out}");
+}
+
+#[test]
+fn gitignore_above_cwd_is_not_consulted() {
+    let parent = tmpdir();
+    write(&parent, ".gitignore", "child/hidden.md\n");
+    write(&parent, "child/hidden.md", "# visible\n");
+
+    let output = run(&parent.join("child"), &["--check", "*.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_paths_bypass_gitignore_but_not_cli_ignore() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "generated.md\n");
+    write(&root, "generated.md", "# generated\n");
+
+    let output = run(&root, &["--check", "generated.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+
+    let output = run(
+        &root,
+        &["--check", "--ignore", "generated.md", "generated.md"],
+    );
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn ignore_path_is_repeatable_later_rules_win_and_applies_to_explicit() {
+    let root = tmpdir();
+    write(&root, "first.ignore", "area/docs/*.md\n");
+    write(&root, "area/second.ignore", "!docs/keep.md\n");
+    write(&root, "area/docs/drop.md", "# drop\n");
+    write(&root, "area/docs/keep.md", "# keep\n");
+
+    let output = run(
+        &root,
+        &[
+            "--check",
+            "--ignore-path",
+            "first.ignore",
+            "--ignore-path",
+            "area/second.ignore",
+            "area/docs/drop.md",
+            "area/docs/keep.md",
+        ],
+    );
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert!(out.contains("area/docs/keep.md"), "{out}");
+}
+
+#[test]
+fn missing_ignore_path_is_a_hard_error() {
+    let root = tmpdir();
+    let output = run(
+        &root,
+        &["--check", "--ignore-path", "missing.ignore", "**/*.md"],
+    );
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("missing.ignore"));
+}
+
+#[test]
+fn reports_all_bad_operands_and_preserves_original_spelling() {
+    let root = tmpdir();
+    fs::create_dir(root.join("docs")).unwrap();
+    let output = run(&root, &["--check", "docs", "missing.md"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stderr(&output),
+        "docs: is a directory (pass a glob such as 'docs/**/*.md' to format its contents)\nmissing.md: no such file\n"
+    );
+}
+
+#[test]
+fn braces_are_literal_and_magic_patterns_with_no_matches_exit_zero() {
+    let root = tmpdir();
+    let braces = run(&root, &["--check", "a{b,c}.md"]);
+    assert_eq!(braces.status.code(), Some(1));
+    assert_eq!(stderr(&braces), "a{b,c}.md: no such file\n");
+
+    let magic = run(&root, &["--check", "missing/*.md"]);
+    assert!(magic.status.success());
+    assert_eq!(stdout(&magic), "No files found matching the patterns.\n");
+}
+
+#[test]
+fn stat_precedes_magic_for_real_names_containing_glob_characters() {
+    let root = tmpdir();
+    write(&root, "real[1].md", "# real\n");
+    fs::create_dir(root.join("dir*name")).unwrap();
+
+    let file = run(&root, &["--check", "real[1].md"]);
+    assert!(stdout(&file).contains("real[1].md"));
+
+    let directory = run(&root, &["--check", "dir*name"]);
+    assert_eq!(directory.status.code(), Some(1));
+    assert_eq!(
+        stderr(&directory),
+        "dir*name: is a directory (pass a glob such as 'dir*name/**/*.md' to format its contents)\n"
+    );
+}
+
+#[test]
+fn windows_separators_are_accepted_and_explicit_spelling_is_preserved() {
+    let root = tmpdir();
+    write(&root, "docs/file.md", "# test\n");
+    let output = run(&root, &["--check", "docs\\file.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("docs\\file.md"), "{out}");
+}
+
+#[test]
+fn explicit_semantics_win_when_glob_also_matches() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "docs/file.md\n");
+    write(&root, "docs/file.md", "# test\n");
+    let output = run(&root, &["--check", "**/*.md", "docs/file.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert_eq!(out.matches("docs/file.md").count(), 1);
+}
+
+#[test]
+fn dry_run_zero_file_messages_are_stderr_only() {
+    let root = tmpdir();
+    let output = run(&root, &["--dry-run", "**/*.md"]);
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(stderr(&output), "No files found matching the patterns.\n");
+}
+
+#[test]
+fn dry_run_all_filtered_message_is_stderr_only() {
+    let root = tmpdir();
+    write(&root, "hidden.md", "# hidden\n");
+    let output = run(&root, &["--dry-run", "--ignore", "hidden.md", "*.md"]);
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        stderr(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn default_patterns_are_applied_in_code_and_cover_md_and_mdx() {
+    let root = tmpdir();
+    write(&root, "one.md", "# one\n");
+    write(&root, "nested/two.mdx", "# two\n");
+    let output = run(&root, &["--check"]);
+    assert!(stdout(&output).contains("Processing 2 file(s)..."));
+}
+
+#[test]
+fn walk_does_not_consult_dot_ignore_or_git_info_exclude() {
+    let root = tmpdir();
+    write(&root, ".ignore", "visible.md\n");
+    write(&root, ".git/info/exclude", "visible.md\n");
+    write(&root, "visible.md", "# visible\n");
+    let output = run(&root, &["--check", "*.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn no_gitignore_does_not_disable_explicit_ignore_path() {
+    let root = tmpdir();
+    write(&root, "custom.ignore", "hidden.md\n");
+    write(&root, "hidden.md", "# hidden\n");
+    let output = run(
+        &root,
+        &[
+            "--check",
+            "--no-gitignore",
+            "--ignore-path",
+            "custom.ignore",
+            "*.md",
+        ],
+    );
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn exact_file_symlink_is_followed_and_dangling_symlink_is_missing() {
+    use std::os::unix::fs::symlink;
+
+    let root = tmpdir();
+    write(&root, "target.md", "# target\n");
+    symlink("target.md", root.join("linked.md")).unwrap();
+    symlink("absent.md", root.join("dangling.md")).unwrap();
+
+    let linked = run(&root, &["--check", "linked.md"]);
+    assert!(stdout(&linked).contains("linked.md"));
+
+    let dangling = run(&root, &["--check", "dangling.md"]);
+    assert_eq!(dangling.status.code(), Some(1));
+    assert_eq!(stderr(&dangling), "dangling.md: no such file\n");
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chalk": "^5.3.0",
     "commander": "^14.0.3",
     "glob": "^13.0.1",
+    "ignore": "^7.0.5",
     "js-yaml": "^4.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       glob:
         specifier: ^13.0.1
         version: 13.0.1
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,9 @@ import { formatFile, checkFile, dryRunReport } from './index.js';
 import type { DryRunReportEntry } from './index.js';
 import { loadFullConfig } from './load-config.js';
 import type { FormatOptions } from './types.js';
-import { discoverFiles } from './discover.js';
+import { discoverFiles, normalizeOperand } from './discover.js';
+
+const DEFAULT_PATTERNS = ['**/*.{md,mdx}'];
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
   version: string;
@@ -18,7 +20,7 @@ program
   .name('mdx-formatter')
   .description('AST-based markdown and MDX formatter')
   .version(pkg.version)
-  .argument('[patterns...]', 'Glob patterns for files to format', ['**/*.{md,mdx}'])
+  .argument('[patterns...]', 'Glob patterns or explicit files to format')
   .option('-w, --write', 'Write formatted files in place')
   .option('-c, --check', 'Check if files need formatting')
   .option(
@@ -90,16 +92,37 @@ async function main(
   const { settings, excludePatterns } = loadFullConfig(
     options.config ? { config: options.config } : {},
   );
-  const ignorePatterns = [...new Set([...cliIgnorePatterns, ...excludePatterns])];
   const formatOptions: FormatOptions = { settings };
 
-  const uniqueFiles = await discoverFiles(patterns, ignorePatterns);
+  const operands = patterns.length === 0 ? DEFAULT_PATTERNS : patterns;
+  const {
+    files: uniqueFiles,
+    anyMatchedBeforeFilter,
+    badOperands,
+  } = await discoverFiles(operands, { cliIgnorePatterns, excludePatterns });
+
+  if (badOperands.length > 0) {
+    for (const { operand, reason } of badOperands) {
+      if (reason === 'directory') {
+        const globBase = operand.replace(/[\\/]+$/, '');
+        console.error(
+          `${operand}: is a directory (pass a glob such as '${globBase}/**/*.md' to format its contents)`,
+        );
+      } else {
+        console.error(`${operand}: no such file`);
+      }
+    }
+    process.exit(1);
+  }
 
   if (uniqueFiles.length === 0) {
+    const message = anyMatchedBeforeFilter
+      ? 'All matching files were excluded by ignore/exclude patterns — 0 files to process.'
+      : 'No files found matching the patterns.';
     if (options.dryRun) {
-      console.error(chalk.yellow('No files found matching the patterns.'));
+      console.error(chalk.yellow(message));
     } else {
-      console.log(chalk.yellow('No files found matching the patterns.'));
+      console.log(chalk.yellow(message));
     }
     return;
   }
@@ -115,9 +138,10 @@ async function main(
   let errorCount = 0;
 
   for (const file of uniqueFiles) {
+    const ioPath = normalizeOperand(file);
     try {
       if (options.write) {
-        const changed = await formatFile(file, formatOptions);
+        const changed = await formatFile(ioPath, formatOptions);
         if (changed) {
           changedCount++;
           console.log(chalk.green('✓'), chalk.gray(file), chalk.green('formatted'));
@@ -125,7 +149,7 @@ async function main(
           console.log(chalk.gray('○'), chalk.gray(file), chalk.gray('unchanged'));
         }
       } else if (options.check) {
-        const needsFormatting = await checkFile(file, formatOptions);
+        const needsFormatting = await checkFile(ioPath, formatOptions);
         if (needsFormatting) {
           changedCount++;
           console.log(chalk.yellow('⚠'), chalk.gray(file), chalk.yellow('needs formatting'));
@@ -134,7 +158,7 @@ async function main(
         }
       } else {
         // Default: just show what would be done
-        const needsFormatting = await checkFile(file, formatOptions);
+        const needsFormatting = await checkFile(ioPath, formatOptions);
         if (needsFormatting) {
           changedCount++;
           console.log(chalk.blue('→'), chalk.gray(file), chalk.blue('would be formatted'));
@@ -190,9 +214,10 @@ async function runDryRun(files: string[], formatOptions: FormatOptions): Promise
   let filesWithChanges = 0;
 
   for (const file of files) {
+    const ioPath = normalizeOperand(file);
     let content: string;
     try {
-      content = await fs.readFile(file, 'utf-8');
+      content = await fs.readFile(ioPath, 'utf-8');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`${file}: read error: ${message}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,12 +3,12 @@
 import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
 import { program } from 'commander';
-import { glob } from 'glob';
 import chalk from 'chalk';
 import { formatFile, checkFile, dryRunReport } from './index.js';
 import type { DryRunReportEntry } from './index.js';
 import { loadFullConfig } from './load-config.js';
 import type { FormatOptions } from './types.js';
+import { discoverFiles } from './discover.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
   version: string;
@@ -93,18 +93,7 @@ async function main(
   const ignorePatterns = [...new Set([...cliIgnorePatterns, ...excludePatterns])];
   const formatOptions: FormatOptions = { settings };
 
-  // Find all matching files
-  const files: string[] = [];
-  for (const pattern of patterns) {
-    const matches = await glob(pattern, {
-      ignore: ignorePatterns,
-      nodir: true,
-    });
-    files.push(...matches);
-  }
-
-  // Remove duplicates
-  const uniqueFiles = [...new Set(files)];
+  const uniqueFiles = await discoverFiles(patterns, ignorePatterns);
 
   if (uniqueFiles.length === 0) {
     if (options.dryRun) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,10 @@ const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
   version: string;
 };
 
+function collectOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 program
   .name('mdx-formatter')
   .description('AST-based markdown and MDX formatter')
@@ -38,6 +42,13 @@ program
     'Comma-separated patterns to ignore',
     'node_modules/**,dist/**,build/**,.git/**,worktrees/**',
   )
+  .option(
+    '--ignore-path <file>',
+    'Read .gitignore-style rules from file (repeatable; later files override earlier ones)',
+    collectOption,
+    [],
+  )
+  .option('--no-gitignore', 'Disable automatic .gitignore discovery (enabled by default)')
   .action(
     async (
       patterns: string[],
@@ -47,6 +58,8 @@ program
         dryRun?: boolean;
         config?: string;
         ignore: string;
+        ignorePath: string[];
+        gitignore: boolean;
       },
     ) => {
       try {
@@ -84,6 +97,8 @@ async function main(
     dryRun?: boolean;
     config?: string;
     ignore: string;
+    ignorePath: string[];
+    gitignore: boolean;
   },
 ): Promise<void> {
   const cliIgnorePatterns = options.ignore.split(',').map((p) => p.trim());
@@ -99,7 +114,12 @@ async function main(
     files: uniqueFiles,
     anyMatchedBeforeFilter,
     badOperands,
-  } = await discoverFiles(operands, { cliIgnorePatterns, excludePatterns });
+  } = await discoverFiles(operands, {
+    cliIgnorePatterns,
+    excludePatterns,
+    ignorePaths: options.ignorePath,
+    useGitignore: options.gitignore,
+  });
 
   if (badOperands.length > 0) {
     for (const { operand, reason } of badOperands) {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,6 +1,7 @@
-import { statSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { escape, glob, hasMagic } from 'glob';
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { escape, glob, hasMagic, Ignore as GlobIgnore } from 'glob';
+import ignore, { type Ignore } from 'ignore';
 
 export interface DiscoveryResult {
   files: string[];
@@ -11,6 +12,8 @@ export interface DiscoveryResult {
 export interface DiscoverOptions {
   cliIgnorePatterns: string[];
   excludePatterns: string[];
+  ignorePaths?: string[];
+  useGitignore?: boolean;
   cwd?: string;
 }
 
@@ -57,16 +60,120 @@ async function explicitPathIsIncluded(
   operand: string,
   cwd: string,
   cliIgnorePatterns: string[],
+  suppliedIgnoreFiles: CompiledIgnoreFile[],
 ): Promise<boolean> {
-  if (cliIgnorePatterns.length === 0) return true;
-
   const absolutePath = resolve(cwd, normalizeOperand(operand));
-  const matches = await glob(escape(absolutePath), {
-    cwd,
-    ignore: cliIgnorePatterns,
-    nodir: true,
+  if (cliIgnorePatterns.length > 0) {
+    const matches = await glob(escape(absolutePath), {
+      cwd,
+      ignore: cliIgnorePatterns,
+      nodir: true,
+    });
+    if (matches.length === 0) return false;
+  }
+
+  return !ignoreFilesDecision(absolutePath, false, suppliedIgnoreFiles);
+}
+
+interface CompiledIgnoreFile {
+  directory: string;
+  matcher: Ignore;
+}
+
+interface GlobPath {
+  fullpath(): string;
+  isDirectory(): boolean;
+}
+
+function pathRelativeTo(directory: string, absolutePath: string): string | undefined {
+  const result = relative(directory, absolutePath);
+  if (result === '' || result === '..' || result.startsWith(`..${sep}`) || isAbsolute(result)) {
+    return undefined;
+  }
+  return normalizeOperand(result);
+}
+
+function testIgnoreFile(
+  absolutePath: string,
+  isDirectory: boolean,
+  compiled: CompiledIgnoreFile,
+): boolean | undefined {
+  const relativePath = pathRelativeTo(compiled.directory, absolutePath);
+  if (relativePath === undefined) return undefined;
+
+  const result = compiled.matcher.test(isDirectory ? `${relativePath}/` : relativePath);
+  if (result.ignored) return true;
+  if (result.unignored) return false;
+  return undefined;
+}
+
+/** Evaluate files in the supplied order, retaining the last matching decision. */
+function ignoreFilesDecision(
+  absolutePath: string,
+  isDirectory: boolean,
+  compiledFiles: CompiledIgnoreFile[],
+): boolean {
+  let ignored = false;
+  for (const compiled of compiledFiles) {
+    const decision = testIgnoreFile(absolutePath, isDirectory, compiled);
+    if (decision !== undefined) ignored = decision;
+  }
+  return ignored;
+}
+
+function loadSuppliedIgnoreFiles(paths: string[], cwd: string): CompiledIgnoreFile[] {
+  return paths.map((file) => {
+    const absolutePath = resolve(cwd, normalizeOperand(file));
+    let rules: string;
+    try {
+      rules = readFileSync(absolutePath, 'utf-8');
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Cannot read ignore file '${file}': ${detail}`);
+    }
+    return {
+      directory: dirname(absolutePath),
+      matcher: ignore({ ignorecase: false }).add(rules),
+    };
   });
-  return matches.length > 0;
+}
+
+function createAutoGitignoreLoader(): (directory: string) => CompiledIgnoreFile | null {
+  const cache = new Map<string, CompiledIgnoreFile | null>();
+  return (directory) => {
+    const absoluteDirectory = resolve(directory);
+    const cached = cache.get(absoluteDirectory);
+    if (cached !== undefined) return cached;
+
+    try {
+      const rules = readFileSync(resolve(absoluteDirectory, '.gitignore'), 'utf-8');
+      const compiled = {
+        directory: absoluteDirectory,
+        matcher: ignore({ ignorecase: false }).add(rules),
+      };
+      cache.set(absoluteDirectory, compiled);
+      return compiled;
+    } catch {
+      cache.set(absoluteDirectory, null);
+      return null;
+    }
+  };
+}
+
+function ancestorDirectories(cwd: string, leafDirectory: string): string[] {
+  const relativeLeaf = relative(cwd, leafDirectory);
+  if (relativeLeaf === '..' || relativeLeaf.startsWith(`..${sep}`) || isAbsolute(relativeLeaf)) {
+    return [];
+  }
+
+  const directories = [cwd];
+  if (relativeLeaf === '') return directories;
+  let current = cwd;
+  for (const part of relativeLeaf.split(sep)) {
+    current = resolve(current, part);
+    directories.push(current);
+  }
+  return directories;
 }
 
 export async function discoverFiles(
@@ -75,36 +182,77 @@ export async function discoverFiles(
 ): Promise<DiscoveryResult> {
   const cwd = options.cwd ?? process.cwd();
   const { explicitPaths, globPatterns, badOperands } = classifyOperands(operands, cwd);
+  const suppliedIgnoreFiles = loadSuppliedIgnoreFiles(options.ignorePaths ?? [], cwd);
+  const loadAutoGitignore = createAutoGitignoreLoader();
   const filesByAbsolutePath = new Map<string, string>();
   let anyMatchedBeforeFilter = explicitPaths.length > 0;
 
   // Seed explicit paths first so their spelling and filter-bypass semantics win
   // when a later glob resolves to the same file.
   for (const operand of explicitPaths) {
-    if (await explicitPathIsIncluded(operand, cwd, options.cliIgnorePatterns)) {
+    if (
+      await explicitPathIsIncluded(operand, cwd, options.cliIgnorePatterns, suppliedIgnoreFiles)
+    ) {
       filesByAbsolutePath.set(resolve(cwd, normalizeOperand(operand)), operand);
     }
   }
 
-  const globIgnorePatterns = [
-    ...new Set([...options.cliIgnorePatterns, ...options.excludePatterns]),
-  ];
+  const hardIgnore = new GlobIgnore(
+    [...new Set([...options.cliIgnorePatterns, ...options.excludePatterns])],
+    {},
+  );
+  const gitignoreEnabled = options.useGitignore ?? true;
   for (const originalPattern of globPatterns) {
     const pattern = normalizeOperand(originalPattern);
+    let filteredDuringWalk = false;
+    const ignoredByGitRules = (path: GlobPath): boolean => {
+      const absolutePath = path.fullpath();
+      const directory = path.isDirectory();
+      let ignored = false;
+
+      if (gitignoreEnabled) {
+        for (const ancestor of ancestorDirectories(cwd, dirname(absolutePath))) {
+          const compiled = loadAutoGitignore(ancestor);
+          if (compiled === null) continue;
+          const decision = testIgnoreFile(absolutePath, directory, compiled);
+          if (decision !== undefined) ignored = decision;
+        }
+      }
+
+      for (const compiled of suppliedIgnoreFiles) {
+        const decision = testIgnoreFile(absolutePath, directory, compiled);
+        if (decision !== undefined) ignored = decision;
+      }
+      return ignored;
+    };
+    const ignoreCallbacks = {
+      ignored(path: GlobPath): boolean {
+        const result =
+          hardIgnore.ignored(path as Parameters<typeof hardIgnore.ignored>[0]) ||
+          ignoredByGitRules(path);
+        filteredDuringWalk ||= result;
+        return result;
+      },
+      childrenIgnored(path: GlobPath): boolean {
+        const result =
+          hardIgnore.childrenIgnored(path as Parameters<typeof hardIgnore.childrenIgnored>[0]) ||
+          ignoredByGitRules(path);
+        filteredDuringWalk ||= result;
+        return result;
+      },
+    };
     const matches = await glob(pattern, {
       cwd,
-      ignore: globIgnorePatterns,
+      ignore: ignoreCallbacks,
       nodir: true,
     });
 
     if (matches.length > 0) {
       anyMatchedBeforeFilter = true;
-    } else if (globIgnorePatterns.length > 0) {
-      // D4 needs only the existence of a pre-filter match, never an exact
-      // count. The follow-up gitignore work replaces this fallback with its
-      // pruning-aware ignore callbacks.
-      const unfilteredMatches = await glob(pattern, { cwd, nodir: true });
-      anyMatchedBeforeFilter ||= unfilteredMatches.length > 0;
+    } else if (filteredDuringWalk) {
+      // This deliberately avoids a second unfiltered walk, which would defeat
+      // directory pruning merely to calculate an exact pre-filter count.
+      anyMatchedBeforeFilter = true;
     }
 
     for (const match of matches) {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,0 +1,19 @@
+import { glob } from 'glob';
+
+export async function discoverFiles(
+  patterns: string[],
+  ignorePatterns: string[],
+): Promise<string[]> {
+  // Find all matching files
+  const files: string[] = [];
+  for (const pattern of patterns) {
+    const matches = await glob(pattern, {
+      ignore: ignorePatterns,
+      nodir: true,
+    });
+    files.push(...matches);
+  }
+
+  // Remove duplicates
+  return [...new Set(files)];
+}

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,19 +1,123 @@
-import { glob } from 'glob';
+import { statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { escape, glob, hasMagic } from 'glob';
 
-export async function discoverFiles(
-  patterns: string[],
-  ignorePatterns: string[],
-): Promise<string[]> {
-  // Find all matching files
-  const files: string[] = [];
-  for (const pattern of patterns) {
-    const matches = await glob(pattern, {
-      ignore: ignorePatterns,
-      nodir: true,
-    });
-    files.push(...matches);
+export interface DiscoveryResult {
+  files: string[];
+  anyMatchedBeforeFilter: boolean;
+  badOperands: Array<{ operand: string; reason: 'missing' | 'directory' }>;
+}
+
+export interface DiscoverOptions {
+  cliIgnorePatterns: string[];
+  excludePatterns: string[];
+  cwd?: string;
+}
+
+export interface ClassifiedOperands {
+  explicitPaths: string[];
+  globPatterns: string[];
+  badOperands: Array<{ operand: string; reason: 'missing' | 'directory' }>;
+}
+
+/** Treat both slash styles as separators, regardless of the host platform. */
+export function normalizeOperand(operand: string): string {
+  return operand.replaceAll('\\', '/');
+}
+
+export function classifyOperands(operands: string[], cwd = process.cwd()): ClassifiedOperands {
+  const explicitPaths: string[] = [];
+  const globPatterns: string[] = [];
+  const badOperands: ClassifiedOperands['badOperands'] = [];
+
+  for (const operand of operands) {
+    const normalized = normalizeOperand(operand);
+    try {
+      const stats = statSync(resolve(cwd, normalized));
+      if (stats.isFile()) {
+        explicitPaths.push(operand);
+      } else if (stats.isDirectory()) {
+        badOperands.push({ operand, reason: 'directory' });
+      } else {
+        badOperands.push({ operand, reason: 'missing' });
+      }
+    } catch {
+      if (hasMagic(normalized, { magicalBraces: true })) {
+        globPatterns.push(operand);
+      } else {
+        badOperands.push({ operand, reason: 'missing' });
+      }
+    }
   }
 
-  // Remove duplicates
-  return [...new Set(files)];
+  return { explicitPaths, globPatterns, badOperands };
+}
+
+async function explicitPathIsIncluded(
+  operand: string,
+  cwd: string,
+  cliIgnorePatterns: string[],
+): Promise<boolean> {
+  if (cliIgnorePatterns.length === 0) return true;
+
+  const absolutePath = resolve(cwd, normalizeOperand(operand));
+  const matches = await glob(escape(absolutePath), {
+    cwd,
+    ignore: cliIgnorePatterns,
+    nodir: true,
+  });
+  return matches.length > 0;
+}
+
+export async function discoverFiles(
+  operands: string[],
+  options: DiscoverOptions,
+): Promise<DiscoveryResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const { explicitPaths, globPatterns, badOperands } = classifyOperands(operands, cwd);
+  const filesByAbsolutePath = new Map<string, string>();
+  let anyMatchedBeforeFilter = explicitPaths.length > 0;
+
+  // Seed explicit paths first so their spelling and filter-bypass semantics win
+  // when a later glob resolves to the same file.
+  for (const operand of explicitPaths) {
+    if (await explicitPathIsIncluded(operand, cwd, options.cliIgnorePatterns)) {
+      filesByAbsolutePath.set(resolve(cwd, normalizeOperand(operand)), operand);
+    }
+  }
+
+  const globIgnorePatterns = [
+    ...new Set([...options.cliIgnorePatterns, ...options.excludePatterns]),
+  ];
+  for (const originalPattern of globPatterns) {
+    const pattern = normalizeOperand(originalPattern);
+    const matches = await glob(pattern, {
+      cwd,
+      ignore: globIgnorePatterns,
+      nodir: true,
+    });
+
+    if (matches.length > 0) {
+      anyMatchedBeforeFilter = true;
+    } else if (globIgnorePatterns.length > 0) {
+      // D4 needs only the existence of a pre-filter match, never an exact
+      // count. The follow-up gitignore work replaces this fallback with its
+      // pruning-aware ignore callbacks.
+      const unfilteredMatches = await glob(pattern, { cwd, nodir: true });
+      anyMatchedBeforeFilter ||= unfilteredMatches.length > 0;
+    }
+
+    for (const match of matches) {
+      const absolutePath = resolve(cwd, normalizeOperand(match));
+      if (!filesByAbsolutePath.has(absolutePath)) {
+        filesByAbsolutePath.set(absolutePath, match);
+      }
+    }
+  }
+
+  return {
+    files: [...filesByAbsolutePath.values()],
+    anyMatchedBeforeFilter,
+    badOperands,
+  };
 }

--- a/test/cli-discovery.test.ts
+++ b/test/cli-discovery.test.ts
@@ -1,0 +1,84 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runCli } from './test-helpers.js';
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'mdx-cli-gitignore-'));
+}
+
+async function writeFile(root: string, relativePath: string, content = '# Title\n'): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, content, 'utf-8');
+}
+
+describe('CLI gitignore discovery', () => {
+  it('skips the nested #140 repro by default and restores it with --no-gitignore', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'docs/.gitignore', 'generated/\n');
+    await writeFile(
+      cwd,
+      'docs/generated/page.mdx',
+      '# Generated\nBody without the required blank line\n',
+    );
+
+    const ignored = await runCli(['--check'], { cwd });
+    const included = await runCli(['--check', '--no-gitignore'], { cwd });
+
+    expect(ignored.code).toBe(0);
+    expect(ignored.stdout).not.toContain('docs/generated/page.mdx');
+    expect(included.code).toBe(1);
+    expect(included.stdout).toContain('docs/generated/page.mdx');
+  }, 30_000);
+
+  it('keeps explicit paths exempt from automatic gitignore', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'generated/\n');
+    await writeFile(cwd, 'generated/page.mdx');
+
+    const result = await runCli(['--check', 'generated/page.mdx'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+  }, 30_000);
+
+  it('applies repeatable --ignore-path files in order to explicit paths', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.first-ignore', '*.md\n');
+    await writeFile(cwd, '.second-ignore', '!keep.md\n');
+    await writeFile(cwd, 'keep.md');
+
+    const included = await runCli(
+      ['--check', 'keep.md', '--ignore-path', '.first-ignore', '--ignore-path', '.second-ignore'],
+      { cwd },
+    );
+    const excluded = await runCli(['--check', 'keep.md', '--ignore-path', '.first-ignore'], {
+      cwd,
+    });
+
+    expect(included.code).toBe(0);
+    expect(included.stdout).toContain('Processing 1 file(s)...');
+    expect(excluded.code).toBe(0);
+    expect(excluded.stdout).toContain('All matching files were excluded');
+  }, 30_000);
+
+  it('reports a missing --ignore-path as a hard error', async () => {
+    const cwd = await makeTempDir();
+
+    const result = await runCli(['--check', '--ignore-path', 'missing.ignore'], { cwd });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Cannot read ignore file 'missing.ignore'");
+  }, 30_000);
+
+  it('documents the default gitignore behavior and its opt-out in help', async () => {
+    const result = await runCli(['--help']);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('--ignore-path <file>');
+    expect(result.stdout).toContain('--no-gitignore');
+    expect(result.stdout).toMatch(/enabled by\s+default/);
+  }, 30_000);
+});

--- a/test/cli-discovery.test.ts
+++ b/test/cli-discovery.test.ts
@@ -64,6 +64,24 @@ describe('CLI gitignore discovery', () => {
     expect(excluded.stdout).toContain('All matching files were excluded');
   }, 30_000);
 
+  it('keeps --ignore-path active when --no-gitignore disables automatic files', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'keep.md\n');
+    await writeFile(cwd, '.caller-ignore', 'drop.md\n');
+    await writeFile(cwd, 'keep.md');
+    await writeFile(cwd, 'drop.md');
+
+    const result = await runCli(
+      ['--check', '*.md', '--no-gitignore', '--ignore-path', '.caller-ignore'],
+      { cwd },
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+    expect(result.stdout).toContain('keep.md');
+    expect(result.stdout).not.toContain('drop.md');
+  }, 30_000);
+
   it('reports a missing --ignore-path as a hard error', async () => {
     const cwd = await makeTempDir();
 

--- a/test/discover.test.ts
+++ b/test/discover.test.ts
@@ -1,0 +1,265 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { classifyOperands, discoverFiles } from '../src/discover.js';
+import { runCli } from './test-helpers.js';
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'mdx-discover-'));
+}
+
+async function writeFile(root: string, relativePath: string, content = '# Title\n'): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, content, 'utf-8');
+}
+
+describe('classifyOperands', () => {
+  it('stats operands before checking glob magic and reports every bad operand', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'plain.md');
+    await writeFile(cwd, 'a[1].md');
+    await writeFile(cwd, '.claude/skills/x/SKILL.md');
+    await fs.mkdir(path.join(cwd, 'docs'));
+    await fs.symlink('plain.md', path.join(cwd, 'linked.md'));
+    await fs.symlink('absent.md', path.join(cwd, 'dangling.md'));
+
+    const result = classifyOperands(
+      [
+        'plain.md',
+        'a[1].md',
+        'a{b,c}.md',
+        '**/*.md',
+        'docs',
+        'nope.md',
+        'linked.md',
+        'dangling.md',
+        '.claude/skills/x/SKILL.md',
+      ],
+      cwd,
+    );
+
+    expect(result.explicitPaths).toEqual([
+      'plain.md',
+      'a[1].md',
+      'linked.md',
+      '.claude/skills/x/SKILL.md',
+    ]);
+    expect(result.globPatterns).toEqual(['a{b,c}.md', '**/*.md']);
+    expect(result.badOperands).toEqual([
+      { operand: 'docs', reason: 'directory' },
+      { operand: 'nope.md', reason: 'missing' },
+      { operand: 'dangling.md', reason: 'missing' },
+    ]);
+  });
+
+  it('accepts Windows separators while preserving the operand spelling', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    expect(classifyOperands([operand], cwd).explicitPaths).toEqual([operand]);
+  });
+});
+
+describe('discoverFiles', () => {
+  it('lets explicit paths bypass config exclude and gives them dedupe precedence', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await discoverFiles(['foo.md', '*.md'], {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: ['foo.md'],
+    });
+
+    expect(result.files).toEqual(['foo.md']);
+    expect(result.anyMatchedBeforeFilter).toBe(true);
+    expect(result.badOperands).toEqual([]);
+  });
+
+  it('applies CLI ignore to explicit paths', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await discoverFiles(['foo.md'], {
+      cwd,
+      cliIgnorePatterns: ['foo.md'],
+      excludePatterns: [],
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.anyMatchedBeforeFilter).toBe(true);
+  });
+
+  it('distinguishes an excluded glob match from a glob with no matches', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    const options = {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: ['tests/**'],
+    };
+
+    const excluded = await discoverFiles(['tests/**/*.md'], options);
+    const unmatched = await discoverFiles(['missing/**/*.md'], options);
+
+    expect(excluded.files).toEqual([]);
+    expect(excluded.anyMatchedBeforeFilter).toBe(true);
+    expect(unmatched.files).toEqual([]);
+    expect(unmatched.anyMatchedBeforeFilter).toBe(false);
+  });
+
+  it('preserves Windows spelling for an explicit result', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    const result = await discoverFiles([operand], {
+      cwd,
+      cliIgnorePatterns: [],
+      excludePatterns: [],
+    });
+
+    expect(result.files).toEqual([operand]);
+  });
+});
+
+describe('CLI discovery', () => {
+  it.each([
+    ['.claude/skills/example/SKILL.md', '.claude/**'],
+    ['tests/foo.md', 'tests/**'],
+  ])(
+    'checks explicit %s despite config exclude',
+    async (operand, exclude) => {
+      const cwd = await makeTempDir();
+      await writeFile(cwd, operand);
+      await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude }));
+
+      const result = await runCli(['--check', operand], { cwd });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Processing 1 file(s)...');
+      expect(result.stdout).toContain(operand);
+      expect(result.stdout).not.toContain('No files found');
+    },
+    30_000,
+  );
+
+  it('keeps explicit discovery unchanged with an empty exclude', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: [] }));
+
+    const result = await runCli(['--check', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+  }, 30_000);
+
+  it('gives --write explicit paths the config-exclude bypass', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['foo.md'] }));
+
+    const result = await runCli(['--write', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+  }, 30_000);
+
+  it('keeps CLI ignore authoritative for explicit paths', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'foo.md');
+
+    const result = await runCli(['--check', 'foo.md', '--ignore', 'foo.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('reports when config exclude filters every glob match', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['tests/**'] }));
+
+    const result = await runCli(['--check', 'tests/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('writes the excluded-zero message only to stderr in dry-run mode', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'tests/foo.md');
+    await writeFile(cwd, '.mdx-formatter.json', JSON.stringify({ exclude: ['tests/**'] }));
+
+    const result = await runCli(['--dry-run', 'tests/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'All matching files were excluded by ignore/exclude patterns — 0 files to process.',
+    );
+  }, 30_000);
+
+  it('reports no matches separately', async () => {
+    const cwd = await makeTempDir();
+
+    const result = await runCli(['--check', 'missing/**/*.md'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('No files found matching the patterns.');
+  }, 30_000);
+
+  it('applies default patterns only when no operands were supplied', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'default.md');
+
+    const result = await runCli(['--check'], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Processing 1 file(s)...');
+    expect(result.stdout).toContain('default.md');
+  }, 30_000);
+
+  it('reports all bad operands and never processes the valid subset', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'valid.md');
+    await fs.mkdir(path.join(cwd, 'docs'));
+
+    const result = await runCli(['--check', 'valid.md', 'nope.md', 'docs'], { cwd });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('nope.md: no such file');
+    expect(result.stderr).toContain(
+      "docs: is a directory (pass a glob such as 'docs/**/*.md' to format its contents)",
+    );
+    expect(result.stdout).not.toContain('Processing');
+  }, 30_000);
+
+  it('treats bad dry-run operands as usage errors', async () => {
+    const cwd = await makeTempDir();
+
+    const result = await runCli(['--dry-run', 'nope.md'], { cwd });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('nope.md: no such file');
+  }, 30_000);
+
+  it('processes Windows-separated explicit paths and preserves their output spelling', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'nested/file.md');
+    const operand = 'nested\\file.md';
+
+    const result = await runCli(['--check', operand], { cwd });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(operand);
+  }, 30_000);
+});

--- a/test/discover.test.ts
+++ b/test/discover.test.ts
@@ -64,6 +64,8 @@ describe('classifyOperands', () => {
 });
 
 describe('discoverFiles', () => {
+  const baseOptions = { cliIgnorePatterns: [], excludePatterns: [] };
+
   it('lets explicit paths bypass config exclude and gives them dedupe precedence', async () => {
     const cwd = await makeTempDir();
     await writeFile(cwd, 'foo.md');
@@ -126,6 +128,119 @@ describe('discoverFiles', () => {
     });
 
     expect(result.files).toEqual([operand]);
+  });
+
+  it('honors root and nested gitignore files using each file as its anchor', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', '/root-only.md\n');
+    await writeFile(cwd, 'docs/.gitignore', 'generated/\n');
+    await writeFile(cwd, 'root-only.md');
+    await writeFile(cwd, 'docs/root-only.md');
+    await writeFile(cwd, 'docs/generated/page.mdx');
+    await writeFile(cwd, 'generated/page.mdx');
+
+    const result = await discoverFiles(['**/*.{md,mdx}'], { cwd, ...baseOptions });
+
+    expect(result.files.sort()).toEqual(['docs/root-only.md', 'generated/page.mdx']);
+  });
+
+  it('lets deeper gitignore decisions override shallower decisions', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', '*.md\n');
+    await writeFile(cwd, 'docs/.gitignore', '!keep.md\n');
+    await writeFile(cwd, 'root.md');
+    await writeFile(cwd, 'docs/drop.md');
+    await writeFile(cwd, 'docs/keep.md');
+
+    const result = await discoverFiles(['**/*.md'], { cwd, ...baseOptions });
+
+    expect(result.files).toEqual(['docs/keep.md']);
+  });
+
+  it('uses valid git negation semantics to re-include a child', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'generated/*\n!generated/keep.md\n');
+    await writeFile(cwd, 'generated/drop.md');
+    await writeFile(cwd, 'generated/keep.md');
+
+    const result = await discoverFiles(['**/*.md'], { cwd, ...baseOptions });
+
+    expect(result.files).toEqual(['generated/keep.md']);
+  });
+
+  it('does not consult gitignore files above cwd', async () => {
+    const parent = await makeTempDir();
+    const cwd = path.join(parent, 'project');
+    await writeFile(parent, '.gitignore', '*.md\n');
+    await writeFile(parent, 'project/keep.md');
+
+    const result = await discoverFiles(['**/*.md'], { cwd, ...baseOptions });
+
+    expect(result.files).toEqual(['keep.md']);
+  });
+
+  it('lets explicit paths bypass automatic gitignore but not supplied ignore files', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'generated/\n');
+    await writeFile(cwd, '.caller-ignore', 'generated/keep.md\n');
+    await writeFile(cwd, 'generated/keep.md');
+
+    const automatic = await discoverFiles(['generated/keep.md'], { cwd, ...baseOptions });
+    const supplied = await discoverFiles(['generated/keep.md'], {
+      cwd,
+      ...baseOptions,
+      ignorePaths: ['.caller-ignore'],
+    });
+
+    expect(automatic.files).toEqual(['generated/keep.md']);
+    expect(supplied.files).toEqual([]);
+  });
+
+  it('anchors supplied ignore files and lets later files override earlier ones', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, 'docs/.first-ignore', 'generated/*\n');
+    await writeFile(cwd, 'docs/.second-ignore', '!generated/keep.md\n');
+    await writeFile(cwd, 'docs/generated/drop.md');
+    await writeFile(cwd, 'docs/generated/keep.md');
+    await writeFile(cwd, 'generated/drop.md');
+
+    const result = await discoverFiles(['**/*.md'], {
+      cwd,
+      ...baseOptions,
+      ignorePaths: ['docs/.first-ignore', 'docs/.second-ignore'],
+    });
+
+    expect(result.files.sort()).toEqual(['docs/generated/keep.md', 'generated/drop.md']);
+  });
+
+  it('can disable automatic gitignore discovery', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'generated/\n');
+    await writeFile(cwd, 'generated/page.mdx');
+
+    const result = await discoverFiles(['**/*.mdx'], {
+      cwd,
+      ...baseOptions,
+      useGitignore: false,
+    });
+
+    expect(result.files).toEqual(['generated/page.mdx']);
+  });
+
+  it('prunes a directory ignored with directory-form gitignore syntax', async () => {
+    const cwd = await makeTempDir();
+    await writeFile(cwd, '.gitignore', 'generated/\n');
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        writeFile(cwd, `generated/level-${index}/page-${index}.md`),
+      ),
+    );
+    await writeFile(cwd, 'keep.md');
+
+    const result = await discoverFiles(['**/*.md'], { cwd, ...baseOptions });
+
+    expect(result.files).toEqual(['keep.md']);
+    expect(result.anyMatchedBeforeFilter).toBe(true);
   });
 });
 

--- a/test/discover.test.ts
+++ b/test/discover.test.ts
@@ -79,13 +79,16 @@ describe('discoverFiles', () => {
     expect(result.badOperands).toEqual([]);
   });
 
-  it('applies CLI ignore to explicit paths', async () => {
+  it.each([
+    ['foo.md', 'foo.md'],
+    ['tests/foo.md', 'tests/**'],
+  ])('applies CLI ignore to explicit path %s with %s', async (operand, ignorePattern) => {
     const cwd = await makeTempDir();
-    await writeFile(cwd, 'foo.md');
+    await writeFile(cwd, operand);
 
-    const result = await discoverFiles(['foo.md'], {
+    const result = await discoverFiles([operand], {
       cwd,
-      cliIgnorePatterns: ['foo.md'],
+      cliIgnorePatterns: [ignorePattern],
       excludePatterns: [],
     });
 

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -10,18 +10,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { dryRunReport, format } from '../src/index.js';
-
-const execFileP = promisify(execFile);
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliEntry = path.resolve(__dirname, '../src/cli.ts');
+import { runCli } from './test-helpers.js';
 
 async function mkTmp(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'mdx-dry-run-'));
@@ -116,22 +109,6 @@ describe('dryRunReport library API', () => {
 });
 
 describe('CLI --dry-run flag', () => {
-  async function runCli(args: string[]): Promise<{
-    stdout: string;
-    stderr: string;
-    code: number;
-  }> {
-    try {
-      const { stdout, stderr } = await execFileP('npx', ['tsx', cliEntry, ...args], {
-        cwd: path.resolve(__dirname, '..'),
-      });
-      return { stdout, stderr, code: 0 };
-    } catch (err) {
-      const e = err as { stdout?: string; stderr?: string; code?: number };
-      return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', code: e.code ?? 1 };
-    }
-  }
-
   it('reports changes, leaves file byte-identical, exits 0', async () => {
     const dir = await mkTmp();
     const file = path.join(dir, 'sample.md');

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -6,7 +6,35 @@
  * need the original component names to verify behavior.
  */
 
+import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import type { DeepPartial, FormatterSettings } from '../src/types.js';
+
+const execFileP = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tsxEntry = fileURLToPath(import.meta.resolve('tsx/cli'));
+const cliEntry = path.resolve(repoRoot, 'src/cli.ts');
+
+export async function runCli(
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileP(process.execPath, [tsxEntry, cliEntry, ...args], {
+      cwd: options.cwd ?? repoRoot,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (error) {
+    const result = error as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      code: result.code ?? 1,
+    };
+  }
+}
 
 export const testSettings: DeepPartial<FormatterSettings> = {
   addEmptyLinesInBlockJsx: {


### PR DESCRIPTION
Parent: #156

Implements #159.

## Summary
- honors root and nested `.gitignore` files during Node glob discovery
- anchors rules to each ignore file, applies deeper/later decisions last, and prunes ignored directories
- adds repeatable `--ignore-path` and `--no-gitignore`
- adds `ignore` as a published runtime dependency
- covers negation, cwd boundaries, explicit-path exemptions, and flag precedence

## Validation
- targeted discovery tests (33 tests at topic completion)
- `pnpm test` (290 tests)
- `pnpm lint`
- `pnpm build`
- foreground worker review
