### PR TITLE
[CLI Discovery Fixes] Align Rust discovery semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +161,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +243,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +281,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -314,6 +378,7 @@ dependencies = [
  "clap",
  "colored",
  "glob",
+ "ignore",
  "mdx-formatter-core",
 ]
 
@@ -472,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -511,6 +576,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -641,6 +715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +819,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mdx-formatter-cli/Cargo.toml
+++ b/crates/mdx-formatter-cli/Cargo.toml
@@ -12,4 +12,5 @@ path = "src/main.rs"
 mdx-formatter-core = { path = "../mdx-formatter-core" }
 clap = { version = "4", features = ["derive"] }
 glob = "0.3"
+ignore = "0.4"
 colored = "2"

--- a/crates/mdx-formatter-cli/src/main.rs
+++ b/crates/mdx-formatter-cli/src/main.rs
@@ -1,13 +1,15 @@
 use clap::Parser;
 use colored::Colorize;
 use glob::glob;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::WalkBuilder;
 use mdx_formatter_core::{
     load_full_config, try_format, try_format_with_sink, FullConfig, ReportEntry, VecSink,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process;
 
 /// AST-based markdown and MDX formatter
@@ -15,7 +17,6 @@ use std::process;
 #[command(name = "mdx-formatter", version, about)]
 struct Cli {
     /// Glob patterns for files to format
-    #[arg(default_values_t = vec!["**/*.md".to_string(), "**/*.mdx".to_string()])]
     patterns: Vec<String>,
 
     /// Write formatted files in place
@@ -39,16 +40,95 @@ struct Cli {
     config: Option<String>,
 
     /// Comma-separated patterns to ignore
-    #[arg(long, default_value = "node_modules/**,dist/**,build/**,.git/**,worktrees/**")]
+    #[arg(
+        long,
+        default_value = "node_modules/**,dist/**,build/**,.git/**,worktrees/**"
+    )]
     ignore: String,
+
+    /// Read additional ignore rules from a file (repeatable)
+    #[arg(long = "ignore-path", value_name = "FILE")]
+    ignore_paths: Vec<String>,
+
+    /// Do not automatically load .gitignore files
+    #[arg(long)]
+    no_gitignore: bool,
 }
 
-/// Normalize a path string: strip leading "./" so glob patterns match consistently
-fn normalize_path(path: &str) -> &str {
-    path.strip_prefix("./").unwrap_or(path)
+#[derive(Debug)]
+struct DiscoveredFile {
+    path: PathBuf,
+    display: String,
 }
 
-/// Compile ignore patterns once, silently skipping invalid ones
+#[derive(Default)]
+struct DiscoveryResult {
+    files: Vec<DiscoveredFile>,
+    had_matches: bool,
+    had_filtered_matches: bool,
+}
+
+/// Normalize separators for matching. The original operand is retained for diagnostics.
+fn normalize_operand(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn lexical_absolute(cwd: &Path, path: &Path) -> PathBuf {
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn matching_path(path: &Path, cwd: &Path) -> String {
+    let relative = path.strip_prefix(cwd).unwrap_or(path);
+    relative.to_string_lossy().replace('\\', "/")
+}
+
+fn pattern_is_within_cwd(pattern: &str, cwd: &Path) -> bool {
+    let path = Path::new(pattern);
+    if path.is_absolute() {
+        let cwd = cwd.to_string_lossy().replace('\\', "/");
+        return pattern == cwd || pattern.starts_with(&format!("{cwd}/"));
+    }
+    !path
+        .components()
+        .any(|component| component == Component::ParentDir)
+}
+
+/// Rust's glob crate deliberately has no brace expansion. Consequently `{` is
+/// not magic here: a missing `a{b,c}.md` is reported as a missing literal.
+fn has_glob_magic(operand: &str) -> bool {
+    let mut escaped = false;
+    for ch in operand.chars() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if matches!(ch, '*' | '?' | '[') {
+            return true;
+        }
+    }
+    false
+}
+
+/// Compile CLI/config patterns once, silently skipping invalid ones (legacy behavior).
 fn compile_ignore_patterns(patterns: &[String]) -> Vec<glob::Pattern> {
     patterns
         .iter()
@@ -63,37 +143,267 @@ fn is_ignored(normalized_path: &str, compiled_patterns: &[glob::Pattern]) -> boo
         .any(|pat| pat.matches(normalized_path))
 }
 
-/// Collect files matching the given patterns, excluding ignored ones
-fn collect_files(patterns: &[String], ignore_patterns: &[String]) -> Vec<PathBuf> {
-    let compiled = compile_ignore_patterns(ignore_patterns);
+struct GitignoreCache {
+    cwd: PathBuf,
+    matchers: HashMap<PathBuf, Option<Gitignore>>,
+}
+
+impl GitignoreCache {
+    fn new(cwd: PathBuf) -> Self {
+        Self {
+            cwd,
+            matchers: HashMap::new(),
+        }
+    }
+
+    fn matcher(&mut self, directory: &Path) -> Option<&Gitignore> {
+        self.matchers
+            .entry(directory.to_path_buf())
+            .or_insert_with(|| {
+                let path = directory.join(".gitignore");
+                if !path.is_file() {
+                    return None;
+                }
+                let mut builder = GitignoreBuilder::new(directory);
+                if builder.case_insensitive(false).is_err() {
+                    return None;
+                }
+                let _ = builder.add(path);
+                builder.build().ok()
+            });
+        self.matchers.get(directory).and_then(Option::as_ref)
+    }
+
+    fn is_ignored(&mut self, path: &Path) -> bool {
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+        if !parent.starts_with(&self.cwd) {
+            return false;
+        }
+
+        let directories: Vec<PathBuf> = parent
+            .ancestors()
+            .take_while(|directory| directory.starts_with(&self.cwd))
+            .map(Path::to_path_buf)
+            .collect();
+        let mut ignored = false;
+        for directory in directories.iter().rev() {
+            if let Some(matcher) = self.matcher(directory) {
+                let relative = path.strip_prefix(directory).unwrap_or(path);
+                let matched = matcher.matched_path_or_any_parents(relative, false);
+                if matched.is_ignore() {
+                    ignored = true;
+                } else if matched.is_whitelist() {
+                    ignored = false;
+                }
+            }
+        }
+        ignored
+    }
+}
+
+fn compile_ignore_file(original: &str, cwd: &Path) -> Result<(PathBuf, Gitignore), String> {
+    let normalized = normalize_operand(original);
+    let absolute = lexical_absolute(cwd, Path::new(&normalized));
+    let directory = absolute.parent().unwrap_or(cwd);
+    let mut builder = GitignoreBuilder::new(directory);
+    builder
+        .case_insensitive(false)
+        .map_err(|error| format!("{}: {}", original, error))?;
+    if let Some(error) = builder.add(&absolute) {
+        return Err(format!("{}: {}", original, error));
+    }
+    builder
+        .build()
+        .map(|matcher| (directory.to_path_buf(), matcher))
+        .map_err(|error| format!("{}: {}", original, error))
+}
+
+fn ignored_by_files(path: &Path, matchers: &[(PathBuf, Gitignore)]) -> bool {
+    let mut ignored = false;
+    for (directory, matcher) in matchers {
+        let Ok(relative) = path.strip_prefix(directory) else {
+            continue;
+        };
+        let matched = matcher.matched_path_or_any_parents(relative, false);
+        if matched.is_ignore() {
+            ignored = true;
+        } else if matched.is_whitelist() {
+            ignored = false;
+        }
+    }
+    ignored
+}
+
+fn collect_files(
+    operands: &[String],
+    cli_ignore_patterns: &[String],
+    config_exclude_patterns: &[String],
+    ignore_files: &[(PathBuf, Gitignore)],
+    use_gitignore: bool,
+) -> Result<DiscoveryResult, Vec<String>> {
+    let cwd = std::env::current_dir().map_err(|error| vec![error.to_string()])?;
+    let cli_ignores = compile_ignore_patterns(cli_ignore_patterns);
+    let config_excludes = compile_ignore_patterns(config_exclude_patterns);
+    let mut gitignores = GitignoreCache::new(cwd.clone());
+    let mut errors = Vec::new();
+    let mut explicit = Vec::new();
+    let mut patterns = Vec::new();
+
+    for original in operands {
+        let normalized = normalize_operand(original);
+        let absolute = lexical_absolute(&cwd, Path::new(&normalized));
+        match fs::metadata(&absolute) {
+            Ok(metadata) if metadata.is_file() => explicit.push((absolute, original.clone())),
+            Ok(metadata) if metadata.is_dir() => errors.push(format!(
+                "{}: is a directory (pass a glob such as '{}/**/*.md' to format its contents)",
+                original,
+                original.trim_end_matches(['/', '\\'])
+            )),
+            Ok(_) => errors.push(format!("{}: no such file", original)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if has_glob_magic(&normalized) {
+                    patterns.push(normalized);
+                } else {
+                    errors.push(format!("{}: no such file", original));
+                }
+            }
+            Err(error) => errors.push(format!("{}: {}", original, error)),
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    let mut result = DiscoveryResult::default();
     let mut seen = HashSet::new();
-    let mut files = Vec::new();
 
-    for pattern in patterns {
+    // Explicit operands are inserted first so they win deduplication against glob matches.
+    for (path, display) in explicit {
+        result.had_matches = true;
+        let normalized = matching_path(&path, &cwd);
+        if is_ignored(&normalized, &cli_ignores) || ignored_by_files(&path, ignore_files) {
+            result.had_filtered_matches = true;
+        } else if seen.insert(path.clone()) {
+            result.files.push(DiscoveredFile { path, display });
+        }
+    }
+
+    let compiled_patterns: Vec<(String, glob::Pattern)> = patterns
+        .iter()
+        .filter(|pattern| pattern_is_within_cwd(pattern, &cwd))
+        .filter_map(|pattern| {
+            glob::Pattern::new(pattern)
+                .ok()
+                .map(|compiled| (pattern.clone(), compiled))
+        })
+        .collect();
+
+    // WalkBuilder prunes ignored directories while loading only per-tree .gitignore
+    // files. Explicitly disable every additional ignore source that the Node CLI
+    // does not consult.
+    let mut walker = WalkBuilder::new(&cwd);
+    walker
+        .hidden(false)
+        .ignore(false)
+        .git_ignore(use_gitignore)
+        .git_global(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false);
+    for entry in walker.build().filter_map(Result::ok) {
+        let Some(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() && !entry.path().is_file() {
+            continue;
+        }
+        let absolute = lexical_absolute(&cwd, entry.path());
+        let relative = matching_path(&absolute, &cwd);
+        let matched_pattern = compiled_patterns.iter().find(|(source, compiled)| {
+            if Path::new(source).is_absolute() {
+                compiled.matches(&absolute.to_string_lossy().replace('\\', "/"))
+            } else {
+                compiled.matches(&relative)
+            }
+        });
+        let Some((source, _)) = matched_pattern else {
+            continue;
+        };
+        result.had_matches = true;
+        if seen.contains(&absolute) {
+            continue;
+        }
+        let filtered = is_ignored(&relative, &cli_ignores)
+            || is_ignored(&relative, &config_excludes)
+            || ignored_by_files(&absolute, ignore_files);
+        if filtered {
+            result.had_filtered_matches = true;
+        } else {
+            seen.insert(absolute.clone());
+            result.files.push(DiscoveredFile {
+                path: absolute.clone(),
+                display: if Path::new(source).is_absolute() {
+                    absolute.to_string_lossy().into_owned()
+                } else {
+                    relative
+                },
+            });
+        }
+    }
+
+    // Patterns rooted outside cwd cannot be served by the cwd pruning walk.
+    // Preserve the CLI's existing support for those operands with glob's
+    // no-follow traversal; cwd .gitignore files intentionally do not apply.
+    for pattern in patterns
+        .iter()
+        .filter(|pattern| !pattern_is_within_cwd(pattern, &cwd))
+    {
         if let Ok(entries) = glob(pattern) {
-            for entry in entries.flatten() {
-                // Skip directories
-                if entry.is_dir() {
+            for entry in entries.flatten().filter(|entry| entry.is_file()) {
+                result.had_matches = true;
+                let absolute = lexical_absolute(&cwd, &entry);
+                if seen.contains(&absolute) {
                     continue;
                 }
-
-                let path_str = entry.to_string_lossy().to_string();
-                let normalized = normalize_path(&path_str).to_string();
-
-                // Skip ignored paths
-                if is_ignored(&normalized, &compiled) {
-                    continue;
-                }
-
-                // Deduplicate by normalized path
-                if seen.insert(normalized) {
-                    files.push(entry);
+                let normalized = matching_path(&absolute, &cwd);
+                let filtered = is_ignored(&normalized, &cli_ignores)
+                    || is_ignored(&normalized, &config_excludes)
+                    || ignored_by_files(&absolute, ignore_files);
+                if filtered {
+                    result.had_filtered_matches = true;
+                } else {
+                    seen.insert(absolute.clone());
+                    result.files.push(DiscoveredFile {
+                        path: absolute,
+                        display: entry.to_string_lossy().into_owned(),
+                    });
                 }
             }
         }
     }
 
-    files
+    // The pruning walk cannot yield a file hidden by .gitignore. Probe only
+    // until the first such match so D4 can distinguish "no match" from "all
+    // filtered" without computing or reporting a pre-filter count.
+    if use_gitignore && !result.had_matches {
+        'patterns: for pattern in patterns {
+            if let Ok(entries) = glob(&pattern) {
+                for entry in entries.flatten() {
+                    if entry.is_file() {
+                        let absolute = lexical_absolute(&cwd, &entry);
+                        if gitignores.is_ignored(&absolute) {
+                            result.had_matches = true;
+                            result.had_filtered_matches = true;
+                            break 'patterns;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(result)
 }
 
 /// Render one ReportEntry to `stderr` in the stable `--dry-run` format.
@@ -143,26 +453,66 @@ fn main() {
     // Load config using the core library's 3-layer merge
     let loaded: FullConfig = load_full_config(cli.config.as_deref(), None);
 
-    // Merge CLI ignore patterns with config exclude patterns
-    let mut all_ignore: Vec<String> = cli
+    let cli_ignore: Vec<String> = cli
         .ignore
         .split(',')
         .map(|s| s.trim().to_string())
         .collect();
-    for pattern in &loaded.exclude_patterns {
-        if !all_ignore.contains(pattern) {
-            all_ignore.push(pattern.clone());
+
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(error) => {
+            eprintln!("{}", error);
+            process::exit(1);
+        }
+    };
+    let mut ignore_files = Vec::new();
+    let mut ignore_file_errors = Vec::new();
+    for path in &cli.ignore_paths {
+        match compile_ignore_file(path, &cwd) {
+            Ok(matcher) => ignore_files.push(matcher),
+            Err(error) => ignore_file_errors.push(error),
         }
     }
+    if !ignore_file_errors.is_empty() {
+        for error in ignore_file_errors {
+            eprintln!("{}", error);
+        }
+        process::exit(1);
+    }
 
-    // Collect files
-    let files = collect_files(&cli.patterns, &all_ignore);
+    let patterns = if cli.patterns.is_empty() {
+        vec!["**/*.md".to_string(), "**/*.mdx".to_string()]
+    } else {
+        cli.patterns.clone()
+    };
+    let discovery = match collect_files(
+        &patterns,
+        &cli_ignore,
+        &loaded.exclude_patterns,
+        &ignore_files,
+        !cli.no_gitignore,
+    ) {
+        Ok(discovery) => discovery,
+        Err(errors) => {
+            for error in errors {
+                eprintln!("{}", error);
+            }
+            process::exit(1);
+        }
+    };
+    let files = discovery.files;
 
     if files.is_empty() {
-        if cli.dry_run {
-            eprintln!("{}", "No files found matching the patterns.".yellow());
+        let message = if discovery.had_matches && discovery.had_filtered_matches {
+            "All matching files were excluded by ignore/exclude patterns — 0 files to process."
         } else {
-            println!("{}", "No files found matching the patterns.".yellow());
+            "No files found matching the patterns."
+        };
+        if cli.dry_run {
+            eprintln!("{}", message.yellow());
+        } else {
+            println!("{}", message.yellow());
         }
         return;
     }
@@ -181,9 +531,9 @@ fn main() {
     let mut error_count = 0u32;
 
     for file in &files {
-        let path_str = file.to_string_lossy();
+        let path_str = &file.display;
 
-        match fs::read_to_string(file) {
+        match fs::read_to_string(&file.path) {
             Ok(content) => {
                 let formatted = match try_format(&content, &loaded.settings) {
                     Ok(result) => result,
@@ -202,7 +552,7 @@ fn main() {
 
                 if cli.write {
                     if needs_formatting {
-                        if let Err(e) = fs::write(file, &formatted) {
+                        if let Err(e) = fs::write(&file.path, &formatted) {
                             error_count += 1;
                             eprintln!(
                                 "{} {} {}",
@@ -308,10 +658,7 @@ fn main() {
     }
 
     if error_count > 0 {
-        eprintln!(
-            "{}",
-            format!("✗ {} error(s) occurred", error_count).red()
-        );
+        eprintln!("{}", format!("✗ {} error(s) occurred", error_count).red());
         process::exit(1);
     }
 
@@ -324,15 +671,15 @@ fn main() {
 /// to disk. Always exits 0. Errors reading/parsing individual files are
 /// reported as stderr lines but do NOT change the exit code — dry-run is an
 /// audit tool and must not fail CI when a file is malformed.
-fn run_dry_run(files: &[PathBuf], loaded: &FullConfig) {
+fn run_dry_run(files: &[DiscoveredFile], loaded: &FullConfig) {
     let stderr = io::stderr();
     let mut err = stderr.lock();
     let mut total_entries = 0usize;
     let mut files_with_changes = 0usize;
 
     for file in files {
-        let path_str = file.to_string_lossy();
-        let content = match fs::read_to_string(file) {
+        let path_str = &file.display;
+        let content = match fs::read_to_string(&file.path) {
             Ok(c) => c,
             Err(e) => {
                 let _ = writeln!(err, "{}: read error: {}", path_str, e);
@@ -356,7 +703,7 @@ fn run_dry_run(files: &[PathBuf], loaded: &FullConfig) {
         files_with_changes += 1;
         for entry in &sink.entries {
             total_entries += 1;
-            let _ = write_report_entry(&mut err, &path_str, entry);
+            let _ = write_report_entry(&mut err, path_str, entry);
         }
     }
 

--- a/crates/mdx-formatter-cli/tests/discovery.rs
+++ b/crates/mdx-formatter-cli/tests/discovery.rs
@@ -1,0 +1,336 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn cli_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mdx-formatter"))
+}
+
+fn tmpdir() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let path = env::temp_dir().join(format!(
+        "mdx-formatter-discovery-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(cli_bin())
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn nested_gitignore_hides_generated_mdx_issue_140() {
+    let root = tmpdir();
+    write(&root, "docs/.gitignore", "generated/\n");
+    write(&root, "docs/generated/page.mdx", "# hidden\n");
+
+    let output = run(&root, &["--check", "**/*.mdx"]);
+    assert!(output.status.success());
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+
+    let output = run(&root, &["--check", "--no-gitignore", "**/*.mdx"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_dot_path_bypasses_config_exclude_issue_123_cases_1_and_2() {
+    let root = tmpdir();
+    write(&root, ".claude/skills/example/SKILL.md", "# test\n");
+    write(
+        &root,
+        ".mdx-formatter.json",
+        r#"{"exclude":[".claude/**"]}"#,
+    );
+
+    let output = run(&root, &["--check", ".claude/skills/example/SKILL.md"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+
+    write(&root, ".mdx-formatter.json", r#"{"exclude":[]}"#);
+    let output = run(&root, &["--check", ".claude/skills/example/SKILL.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_plain_path_bypasses_config_exclude_issue_123_case_3() {
+    let root = tmpdir();
+    write(&root, "tests/foo.md", "# test\n");
+    write(&root, ".mdx-formatter.json", r#"{"exclude":["tests/**"]}"#);
+
+    let output = run(&root, &["--check", "tests/foo.md"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn glob_matches_still_honor_config_exclude() {
+    let root = tmpdir();
+    write(&root, "tests/foo.md", "# test\n");
+    write(&root, ".mdx-formatter.json", r#"{"exclude":["tests/**"]}"#);
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn nested_gitignore_deeper_rule_wins_and_negation_reincludes_child() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "docs/generated/*\n");
+    write(&root, "docs/.gitignore", "!generated/keep.md\n");
+    write(&root, "docs/generated/drop.md", "# drop\n");
+    write(&root, "docs/generated/keep.md", "# keep\n");
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert!(out.contains("docs/generated/keep.md"), "{out}");
+    assert!(!out.contains("docs/generated/drop.md"), "{out}");
+}
+
+#[test]
+fn gitignore_negation_uses_file_pattern_not_ignored_directory() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "generated/*\n!generated/keep.md\n");
+    write(&root, "generated/drop.md", "# drop\n");
+    write(&root, "generated/keep.md", "# keep\n");
+
+    let output = run(&root, &["--check", "**/*.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("generated/keep.md"), "{out}");
+    assert!(!out.contains("generated/drop.md"), "{out}");
+}
+
+#[test]
+fn gitignore_above_cwd_is_not_consulted() {
+    let parent = tmpdir();
+    write(&parent, ".gitignore", "child/hidden.md\n");
+    write(&parent, "child/hidden.md", "# visible\n");
+
+    let output = run(&parent.join("child"), &["--check", "*.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn explicit_paths_bypass_gitignore_but_not_cli_ignore() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "generated.md\n");
+    write(&root, "generated.md", "# generated\n");
+
+    let output = run(&root, &["--check", "generated.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+
+    let output = run(
+        &root,
+        &["--check", "--ignore", "generated.md", "generated.md"],
+    );
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn ignore_path_is_repeatable_later_rules_win_and_applies_to_explicit() {
+    let root = tmpdir();
+    write(&root, "first.ignore", "area/docs/*.md\n");
+    write(&root, "area/second.ignore", "!docs/keep.md\n");
+    write(&root, "area/docs/drop.md", "# drop\n");
+    write(&root, "area/docs/keep.md", "# keep\n");
+
+    let output = run(
+        &root,
+        &[
+            "--check",
+            "--ignore-path",
+            "first.ignore",
+            "--ignore-path",
+            "area/second.ignore",
+            "area/docs/drop.md",
+            "area/docs/keep.md",
+        ],
+    );
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert!(out.contains("area/docs/keep.md"), "{out}");
+}
+
+#[test]
+fn missing_ignore_path_is_a_hard_error() {
+    let root = tmpdir();
+    let output = run(
+        &root,
+        &["--check", "--ignore-path", "missing.ignore", "**/*.md"],
+    );
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("missing.ignore"));
+}
+
+#[test]
+fn reports_all_bad_operands_and_preserves_original_spelling() {
+    let root = tmpdir();
+    fs::create_dir(root.join("docs")).unwrap();
+    let output = run(&root, &["--check", "docs", "missing.md"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stderr(&output),
+        "docs: is a directory (pass a glob such as 'docs/**/*.md' to format its contents)\nmissing.md: no such file\n"
+    );
+}
+
+#[test]
+fn braces_are_literal_and_magic_patterns_with_no_matches_exit_zero() {
+    let root = tmpdir();
+    let braces = run(&root, &["--check", "a{b,c}.md"]);
+    assert_eq!(braces.status.code(), Some(1));
+    assert_eq!(stderr(&braces), "a{b,c}.md: no such file\n");
+
+    let magic = run(&root, &["--check", "missing/*.md"]);
+    assert!(magic.status.success());
+    assert_eq!(stdout(&magic), "No files found matching the patterns.\n");
+}
+
+#[test]
+fn stat_precedes_magic_for_real_names_containing_glob_characters() {
+    let root = tmpdir();
+    write(&root, "real[1].md", "# real\n");
+    fs::create_dir(root.join("dir*name")).unwrap();
+
+    let file = run(&root, &["--check", "real[1].md"]);
+    assert!(stdout(&file).contains("real[1].md"));
+
+    let directory = run(&root, &["--check", "dir*name"]);
+    assert_eq!(directory.status.code(), Some(1));
+    assert_eq!(
+        stderr(&directory),
+        "dir*name: is a directory (pass a glob such as 'dir*name/**/*.md' to format its contents)\n"
+    );
+}
+
+#[test]
+fn windows_separators_are_accepted_and_explicit_spelling_is_preserved() {
+    let root = tmpdir();
+    write(&root, "docs/file.md", "# test\n");
+    let output = run(&root, &["--check", "docs\\file.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("docs\\file.md"), "{out}");
+}
+
+#[test]
+fn explicit_semantics_win_when_glob_also_matches() {
+    let root = tmpdir();
+    write(&root, ".gitignore", "docs/file.md\n");
+    write(&root, "docs/file.md", "# test\n");
+    let output = run(&root, &["--check", "**/*.md", "docs/file.md"]);
+    let out = stdout(&output);
+    assert!(out.contains("Processing 1 file(s)..."), "{out}");
+    assert_eq!(out.matches("docs/file.md").count(), 1);
+}
+
+#[test]
+fn dry_run_zero_file_messages_are_stderr_only() {
+    let root = tmpdir();
+    let output = run(&root, &["--dry-run", "**/*.md"]);
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(stderr(&output), "No files found matching the patterns.\n");
+}
+
+#[test]
+fn dry_run_all_filtered_message_is_stderr_only() {
+    let root = tmpdir();
+    write(&root, "hidden.md", "# hidden\n");
+    let output = run(&root, &["--dry-run", "--ignore", "hidden.md", "*.md"]);
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        stderr(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[test]
+fn default_patterns_are_applied_in_code_and_cover_md_and_mdx() {
+    let root = tmpdir();
+    write(&root, "one.md", "# one\n");
+    write(&root, "nested/two.mdx", "# two\n");
+    let output = run(&root, &["--check"]);
+    assert!(stdout(&output).contains("Processing 2 file(s)..."));
+}
+
+#[test]
+fn walk_does_not_consult_dot_ignore_or_git_info_exclude() {
+    let root = tmpdir();
+    write(&root, ".ignore", "visible.md\n");
+    write(&root, ".git/info/exclude", "visible.md\n");
+    write(&root, "visible.md", "# visible\n");
+    let output = run(&root, &["--check", "*.md"]);
+    assert!(stdout(&output).contains("Processing 1 file(s)..."));
+}
+
+#[test]
+fn no_gitignore_does_not_disable_explicit_ignore_path() {
+    let root = tmpdir();
+    write(&root, "custom.ignore", "hidden.md\n");
+    write(&root, "hidden.md", "# hidden\n");
+    let output = run(
+        &root,
+        &[
+            "--check",
+            "--no-gitignore",
+            "--ignore-path",
+            "custom.ignore",
+            "*.md",
+        ],
+    );
+    assert_eq!(
+        stdout(&output),
+        "All matching files were excluded by ignore/exclude patterns — 0 files to process.\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn exact_file_symlink_is_followed_and_dangling_symlink_is_missing() {
+    use std::os::unix::fs::symlink;
+
+    let root = tmpdir();
+    write(&root, "target.md", "# target\n");
+    symlink("target.md", root.join("linked.md")).unwrap();
+    symlink("absent.md", root.join("dangling.md")).unwrap();
+
+    let linked = run(&root, &["--check", "linked.md"]);
+    assert!(stdout(&linked).contains("linked.md"));
+
+    let dangling = run(&root, &["--check", "dangling.md"]);
+    assert_eq!(dangling.status.code(), Some(1));
+    assert_eq!(stderr(&dangling), "dangling.md: no such file\n");
+}


### PR DESCRIPTION
Parent: #156

Implements #158.

## Summary
- brings Rust operand classification and filter applicability into lockstep with Node
- adds nested `.gitignore`, repeatable `--ignore-path`, and `--no-gitignore` support
- disables `.ignore`, global gitignore, `.git/info/exclude`, parent lookup, and symlink traversal sources that Node does not use
- preserves Rust `glob 0.3` brace-literal behavior as the one documented divergence
- adds package-scoped discovery integration tests

## Validation
- `cargo test -p mdx-formatter-cli`
- `cargo clippy -p mdx-formatter-cli`
- foreground worker review
